### PR TITLE
Convert sof-sublime-syntax to sof-vscode-syntax

### DIFF
--- a/sof-vscode-syntax/package.json
+++ b/sof-vscode-syntax/package.json
@@ -44,7 +44,7 @@
       {"language": "sof-ifl", "scopeName": "source.ifl", "path": "./syntaxes/ifl.tmLanguage.json"},
       {"language": "sof-lst", "scopeName": "source.lst", "path": "./syntaxes/lst.tmLanguage.json"},
       {"language": "sof-qdt", "scopeName": "source.qdt", "path": "./syntaxes/qdt.tmLanguage.json"},
-      {"language": "sof-qe4", "scopeName": "source.wrs", "path": "./syntaxes/qe4.tmLanguage.json"},
+      {"language": "sof-qe4", "scopeName": "source.qe4", "path": "./syntaxes/qe4.tmLanguage.json"},
       {"language": "sof-bpf", "scopeName": "source.bpf", "path": "./syntaxes/bpf.tmLanguage.json"}
     ]
   }

--- a/sof-vscode-syntax/syntaxes/bpf.tmLanguage.json
+++ b/sof-vscode-syntax/syntaxes/bpf.tmLanguage.json
@@ -1,6 +1,7 @@
 {
   "scopeName": "source.bpf",
   "name": "SoF - Hidebot Personality File",
+  "firstLineMatch": "^userinfo",
   "patterns": [
     { "include": "#comment" },
     { "include": "#numbers" },
@@ -10,29 +11,83 @@
     { "include": "#userinfo" }
   ],
   "repository": {
-    "comment": { "patterns": [ { "name": "comment.line.number-sign.bpf", "match": "#.*$" } ] },
-    "numbers": { "patterns": [ { "name": "constant.numeric.bpf", "match": "\\b\\d+\\b" } ] },
-    "strings": { "patterns": [ { "name": "string.quoted.double.bpf", "begin": "\"", "end": "\"" } ] },
+    "comment": {
+      "patterns": [
+        {
+          "name": "comment.line.number-sign.bpf",
+          "begin": "#",
+          "end": "$",
+          "patterns": [
+            {
+              "name": "comment.bpf",
+              "match": ".*"
+            }
+          ]
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.bpf",
+          "match": "(?x)(?:(?:\\b\\d(?:[\\d']*\\d)?\\.\\d(?:[\\d']*\\d)?|\\B\\.\\d(?:[\\d']*\\d)?)(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)?(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b|(?:\\b\\d(?:[\\d']*\\d)?\\.)(?:\\B|(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))\\b|(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b\\d(?:[\\d']*\\d)?(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b(?:(?:[1-9](?:[\\d']*\\d)?|0(?:[0-7']*[0-7])?|0[Xx][\\da-fA-F](?:[\\da-fA-F']*[\\da-fA-F])?|0[Bb][01](?:[01']*[01])?)(?:(?:l{1,2}|L{1,2})[uU]?|[uU](?:l{0,2}|L{0,2})|(?:i[fl]?|h|min|[mun]?s|_\\w*))?)\\b)"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.bpf",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.bpf",
+              "match": "\"\""
+            }
+          ]
+        }
+      ]
+    },
     "sections": {
       "patterns": [
-        { "name": "entity.other.inherited-class.bpf", "match": "^\\[\\s*(?:SECT|sect|SECTEND|sectend)\\s*\\]" }
+        {
+          "name": "entity.other.inherited-class.bpf",
+          "match": "^\\[\\s*(?:SECT|sect|SECTEND|sectend)\\s*\\]"
+        }
       ]
     },
     "assignments": {
       "patterns": [
-        { "name": "keyword.declaration.bpf", "match": "\\b(?:accuracy|fov|turning_speed|view_distance|general_intelligence|canchat|chatfreq|SECT|SECTEND)\\b" },
-        { "name": "keyword.operator.assignment.bpf", "match": "=" }
+        {
+          "name": "keyword.declaration.bpf",
+          "match": "\\b(?:accuracy|fov|turning_speed|view_distance|general_intelligence|canchat|chatfreq|SECT|SECTEND)\\b"
+        },
+        {
+          "name": "keyword.operator.assignment.bpf",
+          "match": "="
+        }
       ]
     },
     "userinfo": {
       "patterns": [
-        { "name": "keyword.declaration.userinfo.bpf", "match": "^userinfo\\b" },
-        { "name": "keyword.operator.bpf", "match": "[=\-\*\+<>]" },
-        { "name": "entity.name.bpf", "match": "\\b(?:name|skin)\\b" },
-        { "name": "constant.character.escape.backslash.bpf", "match": "\\\\" }
+        {
+          "name": "keyword.declaration.userinfo.bpf",
+          "match": "^userinfo\\b"
+        },
+        {
+          "name": "keyword.operator.bpf",
+          "match": "[=\\-\\*\\+<>]"
+        },
+        {
+          "name": "entity.name.bpf",
+          "match": "\\b(?:name|skin)\\b"
+        },
+        {
+          "name": "constant.character.escape.backslash.bpf",
+          "match": "\\\\"
+        }
       ]
     }
   }
 }
-
-

--- a/sof-vscode-syntax/syntaxes/cfg.tmLanguage.json
+++ b/sof-vscode-syntax/syntaxes/cfg.tmLanguage.json
@@ -1,17 +1,80 @@
 {
   "scopeName": "source.cfg",
   "name": "SoF - Config",
+  "firstLineMatch": "\\b(set|//)\\b",
   "patterns": [
-    { "include": "#comments" },
-    { "include": "#strings" },
-    { "include": "#macro" },
+    { "include": "#comment" },
+    { "include": "#sof-logger" },
+    { "include": "#macroexpand" },
     { "include": "#numbers" },
+    { "include": "#strings" },
     { "include": "#commands" }
   ],
   "repository": {
-    "comments": {
+    "comment": {
       "patterns": [
-        { "name": "comment.line.double-slash.cfg", "match": "//.*$" }
+        {
+          "name": "comment.line.double-slash.cfg",
+          "begin": "//",
+          "end": "$",
+          "patterns": [
+            {
+              "name": "comment.cfg",
+              "match": ".*"
+            }
+          ]
+        }
+      ]
+    },
+    "sof-logger": {
+      "patterns": [
+        {
+          "name": "comment.line.semicolon.cfg",
+          "begin": "^;",
+          "end": "$",
+          "patterns": [
+            {
+              "name": "comment.cfg",
+              "match": ".*"
+            }
+          ]
+        },
+        {
+          "name": "entity.name.function.cfg",
+          "match": "\\b(log_file|log_file_ip|net_client_port|net_server_ip|net_server_port|net_server_rcon|net_response_timeout_1|net_response_timeout_next|access_level|access_reconnect_timeout|access_kicked_reject_timeout|access_list_file|access_list_file_add|say_init|say_connect_incoming|say_connect_block|say_connect_reject_kicked|say_connect_cancel|poll_interval_status|poll_interval_dumpuser|poll_interval_serverinfo|ping_kick|console_color|player_color)\\b"
+        },
+        {
+          "name": "keyword.operator.assignment.cfg",
+          "match": "="
+        }
+      ]
+    },
+    "macroexpand": {
+      "patterns": [
+        {
+          "name": "constant.character.escape.cfg",
+          "match": "(\\$)|(\\#)"
+        }
+      ]
+    },
+    "localvar": {
+      "patterns": [
+        {
+          "name": "variable.parameter.cfg",
+          "match": "(\\~)(?=\\s)|(\\~)"
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "keyword.punctuation.definition.keyword.cfg",
+          "match": "(\\s\\-)|(\\s\\+)"
+        },
+        {
+          "name": "constant.numeric.cfg",
+          "match": "(?x)(?:(?:\\b\\d(?:[\\d']*\\d)?\\.\\d(?:[\\d']*\\d)?|\\B\\.\\d(?:[\\d']*\\d)?)(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)?(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b|(?:\\b\\d(?:[\\d']*\\d)?\\.)(?:\\B|(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))\\b|(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b\\d(?:[\\d']*\\d)?(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b(?:(?:[1-9](?:[\\d']*\\d)?|0(?:[0-7']*[0-7])?|0[Xx][\\da-fA-F](?:[\\da-fA-F']*[\\da-fA-F])?|0[Bb][01](?:[01']*[01])?)(?:(?:l{1,2}|L{1,2})[uU]?|[uU](?:l{0,2}|L{0,2})|(?:i[fl]?|h|min|[mun]?s|_\\w*))?)\\b)"
+        }
       ]
     },
     "strings": {
@@ -21,50 +84,137 @@
           "begin": "\"",
           "end": "\"",
           "patterns": [
-            { "name": "constant.character.escape.cfg", "match": "\\\\\"" }
+            {
+              "name": "constant.character.escape.cfg",
+              "match": "\"\""
+            }
           ]
         }
-      ]
-    },
-    "macro": {
-      "patterns": [
-        { "name": "constant.character.escape.cfg", "match": "[#$]" },
-        { "name": "variable.parameter.cfg", "match": "~" }
-      ]
-    },
-    "numbers": {
-      "patterns": [
-        { "name": "constant.numeric.cfg", "match": "(?:\\b\\d+\\.\\d+|\\B\\.\\d+|\\b\\d+)(?:[Ee][+-]?\\d+)?" }
       ]
     },
     "commands": {
       "patterns": [
         {
           "name": "keyword.other.cfg",
-          "match": "(?x)(?<!~)\\b(?:wait|stop|stopsound|return|menuoff|popmenu|refresh|killmenu)\\b"
+          "match": "(?<!~)\\b(wait|stop|stopsound|return|menuoff|popmenu|refresh|killmenu)\\b"
         },
         {
           "name": "string.unquoted.command.cfg",
-          "match": "(?x)(?<!~)\\b(?:path|help|info|kill|cpuid|elbow|ninja|pause|score|skins|reload|status|cmdlist|entlist|heretic|ip_list|loading|newsave|phantom|players|vid_front|vid_restart|rawshot|viewpos|z_stats|bigelbow|bindlist|changing|cl_touch|conchars|cvarlist|hackteam|itemdrop|itemnext|itemprev|precache|filter_write|clear|sizeup|sizedown|minimise|usermisc|weapnext|weapprev|itemuse|ff_usejoy|freshgame|heartbeat|imagelist|playlevel|quickload|quicksave|reconnect|reloadall|savesleft|soundinfo|soundlist|unbindall|useritems|savekeys|teamview|userammo|userinfo|getgamestats|putaway|vid_modes|centerview|disconnect|gl_strings|killserver|listignore|playerlist|saveconfig|screenshot|serverinfo|serverstop|togglechat|weapondrop|weaponlose|destroyents|ff_usemouse|filter_list|gsc_connect|listpickups|pingservers|reset_predn|snd_restart|updateinven|userweapons|hackkillbots|list_dmflags|toggleconsole|defaultweapons|gsc_disconnect|maxfpsfromrate|updateinvfinal|weaponbestsafe|gsc_getchannels|killallmonsters|givemoretutorial|turnonmissionmsg|weaponbestunsafe|turnoffmissionmsg|givesnipertutorial|joy_advancedupdateexit)\\b"
+          "match": "(?x)(?<!~)\\b(path|help|info|kill|cpuid|elbow|ninja|pause|score|skins|reload|status|cmdlist|entlist|heretic|ip_list|loading|newsave|phantom|players|vid_front|vid_restart|rawshot|viewpos|z_stats|bigelbow|bindlist|changing|cl_touch|conchars|cvarlist|hackteam|itemdrop|itemnext|itemprev|precache|filter_write|clear|sizeup|sizedown|minimise|usermisc|weapnext|weapprev|itemuse|ff_usejoy|freshgame|heartbeat|imagelist|playlevel|quickload|quicksave|reconnect|reloadall|savesleft|soundinfo|soundlist|unbindall|useritems|savekeys|teamview|userammo|userinfo|getgamestats|putaway|vid_modes|centerview|disconnect|gl_strings|killserver|listignore|playerlist|saveconfig|screenshot|serverinfo|serverstop|togglechat|weapondrop|weaponlose|destroyents|ff_usemouse|filter_list|gsc_connect|listpickups|pingservers|reset_predn|snd_restart|updateinven|userweapons|hackkillbots|list_dmflags|toggleconsole|defaultweapons|gsc_disconnect|maxfpsfromrate|updateinvfinal|weaponbestsafe|gsc_getchannels|killallmonsters|givemoretutorial|turnonmissionmsg|weaponbestunsafe|turnoffmissionmsg|givesnipertutorial|joy_advancedupdateexit)\\b"
         },
-        { "name": "keyword.other.cfg", "match": "(?<!~)\\b(?:error|quit|exit|wipe)\\b" },
-        { "name": "keyword.other.cfg", "match": "(?<!~)\\b(?:rcon)\\b" },
         {
-          "name": "keyword.control.cmd.cfg",
-          "begin": "(?<!~)\\bcmd\\b",
-          "end": "(?=;|$)",
-          "patterns": [
-            { "name": "variable.function.subcommand.cfg", "match": "\\.[A-Za-z0-9_]+" },
-            { "include": "#strings" },
-            { "include": "#numbers" }
-          ]
+          "name": "keyword.other.cfg",
+          "match": "(?<!~)\\b(error|quit|exit|wipe)\\b"
         },
-        { "name": "variable.function.cfg", "match": "(?<!~)\\b(?:bind|unbind)\\b" },
-        { "name": "variable.function.cfg", "match": "(?<!~)\\b(?:set|sset|setenv)\\b" },
-        { "name": "keyword.operator.semicolon.cfg", "match": ";" }
+        {
+          "name": "keyword.other.cfg",
+          "match": "(?<!~)\\b(rcon)\\b"
+        },
+        {
+          "name": "keyword.control.cfg",
+          "match": "(?<!~)\\b(cmd)\\b"
+        },
+        {
+          "name": "variable.function.cfg",
+          "match": "(?x)(?<!~)\\b(or|xor|and|zero|map|add|dir|go|avi|sky|kick|load|menu|ping|play|save|wave|link|winstart|cloud|gimme|ignore|record|messagemode|select|addfave|bot_add|bot_rem|condump|connect|demomap|fx_load|fx_save|gamemap|gsc_ban|gserver|remfave|filter_add|adddownload|loadpoint|ff_tension|forcesong|checkpass|changepass|terrain|dumpuser|gsc_join|gsc_private|gsc_setusermode|gsc_kick|gsc_part|gsc_talk|Say_team|say_team|unignore|ff_spring|intermission|messagemode2|serverrecord|serverstatus|weaponselect|filter_remove|gsc_gettopic|gsc_getusers|gsc_settopic|sv_precache|timerefresh|alias)\\b"
+        },
+        {
+          "name": "variable.function.cfg",
+          "match": "(?<!~)\\b(bind|unbind)\\b"
+        },
+        {
+          "name": "diff.inserted.char.cfg",
+          "match": "(?<!~)\\b(subliminal)\\b"
+        },
+        {
+          "name": "variable.function.cfg",
+          "match": "(?<!~)\\b(echo|say)\\b"
+        },
+        {
+          "name": "variable.function.cfg",
+          "match": "(?<!~)\\b(set_dmflags|unset_dmflags)\\b"
+        },
+        {
+          "name": "variable.function.cfg",
+          "match": "(?<!~)\\b(setenv)\\b"
+        },
+        {
+          "name": "variable.function.cfg",
+          "match": "(?<!~)\\b(set)\\b"
+        },
+        {
+          "name": "variable.function.cfg",
+          "match": "(?<!~)\\b(sset)\\b"
+        },
+        {
+          "name": "keyword.other.cfg",
+          "match": "\\b(bot_name[0-9]+)\\b"
+        },
+        {
+          "name": "keyword.operator.cfg",
+          "match": "(\\!)|(\\+)|(\\-)"
+        },
+        {
+          "name": "variable.function.cfg",
+          "match": "(?x)(?<!~)\\b(sp_sc_alias|sp_sc_cvar_append|sp_sc_cvar_append_newline|sp_sc_cvar_big_text|sp_sc_cvar_copy|sp_sc_cvar_copy_latched|sp_sc_cvar_escape|sp_sc_cvar_math_abs|sp_sc_cvar_math_add|sp_sc_cvar_math_ceil|sp_sc_cvar_math_div|sp_sc_cvar_math_floor|sp_sc_cvar_math_mod|sp_sc_cvar_math_mul|sp_sc_cvar_math_sqrt|sp_sc_cvar_math_sub|sp_sc_cvar_nbsp|sp_sc_cvar_no_color|sp_sc_cvar_random_float|sp_sc_cvar_random_int|sp_sc_cvar_split|sp_sc_cvar_sset|sp_sc_cvar_substr|sp_sc_cvar_unescape|sp_sc_cvar_unhex|sp_sc_cvar_hex|sp_sv_client_cvar_set|sp_sc_cvar_len|sp_sc_info_net|sp_sc_info_net_reset|sp_sc_info_time|sp_sc_uptime|sp_sv_client_check|sp_sv_info_client|sp_sv_info_client_mod|sp_sv_info_frames|sp_sv_players|sp_sv_print_broadcast|sp_sv_print_client|sp_sv_print_sp_broadcast|sp_sv_print_sp_client|sp_sv_sound_broadcast|sp_sv_sound_client|sp_cl_info_map|sp_cl_info_pos|sp_cl_info_skins|sp_cl_debuggraph|tgashot)\\b"
+        },
+        {
+          "name": "keyword.cfg",
+          "match": "^\\.\\b"
+        },
+        {
+          "name": "variable.function.cfg",
+          "match": "(?<!~)\\b(sp_sc_func_alias)\\b"
+        },
+        {
+          "name": "variable.function.cfg",
+          "match": "(?<!~)\\b(sp_sc_cvar_replace)\\b"
+        },
+        {
+          "name": "variable.function.cfg",
+          "match": "(?<!~)\\b(sp_cl_console)\\b"
+        },
+        {
+          "name": "variable.function.cfg",
+          "match": "(?x)(?<!~)\\b(sp_sc_cvar_save|sp_sc_cvar_find|sp_sc_cvar_list|sp_sc_func_list|sp_sv_client_blue|sp_sv_client_play|sp_sv_client_red|sp_sv_client_swap|sp_sv_say_mute|sp_sv_say_unmute)\\b"
+        },
+        {
+          "name": "variable.function.cfg",
+          "match": "(?<!~)\\b(sp_sv_client_spec)\\b"
+        },
+        {
+          "name": "variable.function.cfg",
+          "match": "(?<!~)\\b(sp_sc_file_find)\\b"
+        },
+        {
+          "name": "keyword.other.cfg",
+          "match": "(?<!~)\\b(sp_sc_timer)\\b"
+        },
+        {
+          "name": "keyword.cfg",
+          "match": "(?<!~)\\b(sp_sc_on_change)\\b"
+        },
+        {
+          "name": "keyword.other.cfg",
+          "match": "(?x)(?<!~)\\b(exec|sp_sc_exec_file|sp_sc_func_load_file|sp_sc_func_load_cvar)\\b\\s"
+        },
+        {
+          "name": "keyword.other.cfg",
+          "match": "(?x)(?<!~)\\b(sp_sc_func_exec|sp_sc_exec_cvar)\\b\\s"
+        },
+        {
+          "name": "keyword.control.cfg",
+          "match": "(?<!~)\\b(sp_sc_flow_if|sp_sc_flow_while|else)\\b"
+        },
+        {
+          "name": "variable.function.cfg",
+          "match": "(?x)(?<!~)\\b(sf_sv_ent_use|sf_sv_hook_at|sf_sv_int_add|sf_sv_math_or|sf_sv_ent_anim|sf_sv_ent_find|sf_sv_ent_tint|sf_sv_math_and|sf_sv_math_cos|sf_sv_math_not|sf_sv_math_sin|sf_sv_math_tan|sf_sv_print_cinprintf|sf_sv_ent_spawn|sf_sv_ent_vects|sf_sv_math_acos|sf_sv_math_asin|sf_sv_math_atan|sf_sv_check_reso|sf_sv_draw_clear|sf_sv_ent_create|sf_sv_ent_relink|sf_sv_ent_model|sf_sv_sound_remove|sf_sv_ent_remove|sf_sv_ghoul_list|sf_sv_image_list|sf_sv_player_ent|sf_sv_player_pos|sf_sv_script_run|sf_sv_sound_list|sf_sv_vector_set|sf_sv_draw_string|sf_sv_effect_list|sf_sv_ghoul_scale|sf_sv_player_anim|sf_sv_player_move|sf_sv_script_load|sf_sv_sofree_help|sf_sv_vector_copy|sf_sv_vector_grow|sf_sv_draw_string2|sf_sv_effect_start|sf_sv_ent_callback|sf_sv_mem_read_int|sf_sv_ent_paint|sf_sv_effect_endpos|sf_sv_ent_field_get|sf_sv_ent_field_set|sf_sv_mem_read_char|sf_sv_mem_write_int|sf_sv_player_effect|sf_sv_print_bprintf|sf_sv_print_cprintf|sf_sv_mem_write_string|sf_sv_jmp_at|sf_sv_draw_altstring|sf_sv_ghoul_register|sf_sv_image_register|sf_sv_mem_read_float|sf_sv_mem_read_short|sf_sv_mem_write_char|sf_sv_player_gravity|sf_sv_sound_override|sf_sv_sound_play_ent|sf_int_add|sf_sv_sound_register|sf_sv_effect_register|sf_sv_ghoul_translate|sf_sv_mem_read_string|sf_sv_mem_write_float|sf_sv_mem_write_short|sf_sv_configstring_set|sf_sv_spackage_register|sf_sv_player_paint|sf_sv_player_collision|sf_sv_player_weap_lock|sf_sv_player_allow_walk|sf_sv_player_weap_paint|sf_sv_print_centerprint|sf_sv_sound_play_origin|sf_sv_spackage_print_id|sf_sv_player_allow_altattack|sf_sv_player_weap_switch|sf_sv_print_welcomeprint|sf_sv_spackage_print_ref|sf_sv_player_allow_attack|sf_sv_player_weap_current|sf_sv_spackage_print_obit|sf_sv_spackage_print_string|sf_sv_script_unload|sf_sv_trigger_set_size|sp_sv_ent_create|sp_sv_trigger_set_size|sf_sv_info_client|sf_sv_save_reso)\\b"
+        },
+        {
+          "name": "punctuation.definition.annotation.cfg",
+          "match": ";"
+        }
       ]
     }
   }
 }
-
-

--- a/sof-vscode-syntax/syntaxes/def.tmLanguage.json
+++ b/sof-vscode-syntax/syntaxes/def.tmLanguage.json
@@ -1,25 +1,50 @@
 {
   "scopeName": "source.def",
   "name": "SoF - Definition",
+  "firstLineMatch": "\\/\\*QUAKED",
   "patterns": [
-    { "include": "#comment" },
-    { "include": "#numbers" },
-    {
-      "name": "meta.quaked.def",
-      "begin": "/\\*",
-      "end": "\\*/",
-      "patterns": [
-        { "name": "entity.other.inherited-class.def", "match": "\\b(?:QUAKED|QUAK-ED)\\b" },
-        { "name": "variable.function.def", "match": "\\w+(?=\\s*\\()" },
-        { "name": "string.quoted.double.def", "match": "\\(|\\)" },
-        { "include": "#numbers" }
-      ]
-    }
+    { "include": "#quaked" },
+    { "include": "#numbers" }
   ],
   "repository": {
-    "comment": { "patterns": [ { "name": "comment.block.def", "begin": "/\\*", "end": "\\*/" } ] },
-    "numbers": { "patterns": [ { "name": "constant.numeric.def", "match": "(?:\\b\\d+\\.\\d+|\\B\\.\\d+|\\b\\d+)(?:[Ee][+-]?\\d+)?" } ] }
+    "quaked": {
+      "patterns": [
+        {
+          "name": "entity.other.inherited-class.def",
+          "begin": "(\\/\\*)",
+          "end": "(\\*\\/)",
+          "patterns": [
+            {
+              "name": "entity.other.inherited-class.def",
+              "match": "\\b(QUAKED\\s)|(QUAK-ED\\s)\\b"
+            },
+            {
+              "name": "variable.function.def",
+              "match": "\\w+\\s+(?=\\()"
+            },
+            {
+              "name": "string.quoted.double.def",
+              "match": "\\("
+            },
+            {
+              "name": "string.quoted.double.def",
+              "match": "(\\)\\s+)(?=\\()|(\\))(?=\\()"
+            },
+            {
+              "name": "variable.parameter.function.def",
+              "match": ".*"
+            }
+          ]
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.def",
+          "match": "(?x)(?:(?:\\b\\d(?:[\\d']*\\d)?\\.\\d(?:[\\d']*\\d)?|\\B\\.\\d(?:[\\d']*\\d)?)(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)?(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b|(?:\\b\\d(?:[\\d']*\\d)?\\.)(?:\\B|(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))\\b|(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b\\d(?:[\\d']*\\d)?(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b(?:(?:[1-9](?:[\\d']*\\d)?|0(?:[0-7']*[0-7])?|0[Xx][\\da-fA-F](?:[\\da-fA-F']*[\\da-fA-F])?|0[Bb][01](?:[01']*[01])?)(?:(?:l{1,2}|L{1,2})[uU]?|[uU](?:l{0,2}|L{0,2})|(?:i[fl]?|h|min|[mun]?s|_\\w*))?)\\b)"
+        }
+      ]
+    }
   }
 }
-
-

--- a/sof-vscode-syntax/syntaxes/ds.tmLanguage.json
+++ b/sof-vscode-syntax/syntaxes/ds.tmLanguage.json
@@ -1,31 +1,305 @@
 {
   "scopeName": "source.ds",
   "name": "SoF - Designer Script",
+  "firstLineMatch": "(#include)|(#define)|(output)",
   "patterns": [
-    { "include": "#comment" },
-    { "include": "#strings" },
-    { "include": "#numbers" },
-    { "include": "#keywords" },
-    { "include": "#commands" }
+    { "include": "#comments" },
+    { "include": "#directives" },
+    { "include": "#declarations" },
+    { "include": "#code" },
+    { "include": "#general" },
+    { "include": "#entity" },
+    { "include": "#function" }
   ],
   "repository": {
-    "comment": { "patterns": [ { "name": "comment.line.double-slash.ds", "match": "//.*$" } ] },
-    "strings": {
-      "patterns": [ { "name": "string.quoted.double.ds", "begin": "\"", "end": "\"" } ]
-    },
-    "numbers": { "patterns": [ { "name": "constant.numeric.ds", "match": "(?:\\b\\d+\\.\\d+|\\B\\.\\d+|\\b\\d+)(?:[Ee][+-]?\\d+)?" } ] },
-    "keywords": {
+    "comments": {
       "patterns": [
-        { "name": "keyword.control.ds", "match": "\\b(?:if|endif|else|while|endwhile|on|suspend|resume|exit|label|goto|wait|debug)\\b" }
+        {
+          "name": "comment.block.ds",
+          "begin": "/\\*",
+          "end": "\\*/",
+          "patterns": [
+            {
+              "name": "comment.ds",
+              "match": ".*"
+            }
+          ]
+        },
+        {
+          "name": "comment.line.double-slash.ds",
+          "begin": "//",
+          "end": "$",
+          "patterns": [
+            {
+              "name": "comment.ds",
+              "match": ".*"
+            }
+          ]
+        }
       ]
     },
-    "commands": {
+    "directives": {
       "patterns": [
-        { "name": "variable.function.ds", "match": "\\b(?:print|playsong|\\bplay sound\\b|enable|disable|cache|unload|setcvar cvar|run console command)\\b" },
-        { "name": "entity.name.ds", "match": "\\b(?:remove entity|use entity|reset ai for entity|move entity|rotate entity|moverotate entity|animate entity|copy player attributes from entity|set view angles of entity|set cache size to|helicopter entity|tank entity)\\b" }
+        {
+          "name": "keyword.ds",
+          "match": "(#include)|(output)"
+        },
+        {
+          "name": "keyword.ds",
+          "match": "#define"
+        },
+        {
+          "name": "entity.other.inherited-class.ds",
+          "match": "[a-zA-Z0-9]+\\w+"
+        }
+      ]
+    },
+    "declarations": {
+      "patterns": [
+        {
+          "name": "storage.type.ds",
+          "match": "\\b(parameter|local|global|field)\\b"
+        },
+        {
+          "name": "entity.name.ds",
+          "match": "\\b(int|float|vector|entity)\\b"
+        },
+        {
+          "name": "keyword.operator.ds",
+          "match": "(\\.)|(\\=)|(\\-)|(\\*)|(\\+)|(\\<)|(\\>)|(\\!)|(\\/)"
+        },
+        {
+          "name": "variable.ds",
+          "match": "[a-zA-Z0-9]+\\w+"
+        }
+      ]
+    },
+    "code": {
+      "patterns": [
+        {
+          "name": "keyword.other.ds",
+          "match": "^(on\\s)|^\\s+(on\\s)"
+        },
+        {
+          "name": "keyword.control.ds",
+          "match": "\\b^(if|endif|else|while|endwhile|on|suspend|resume|exit)\\b|^\\s+\\b(if|endif|else|while|endwhile|suspend|resume|exit)\\b"
+        },
+        {
+          "name": "keyword.other.ds",
+          "match": "^(label)|^\\s+(label)"
+        },
+        {
+          "name": "keyword.other.ds",
+          "match": "^(goto)|^\\s+(goto)"
+        },
+        {
+          "name": "keyword.control.ds",
+          "match": "^wait|^\\s+wait"
+        },
+        {
+          "name": "keyword.other.ds",
+          "match": "^debug|^\\s+debug"
+        },
+        {
+          "name": "entity.name.ds",
+          "match": "([a-zA-Z]+(?:_)+\\w+)|([a-zA-Z]+\\w+)"
+        },
+        {
+          "name": "variable.function.ds",
+          "match": "([a-zA-Z]+(?:_)+\\w+)|([a-zA-Z]+\\w+)"
+        }
+      ]
+    },
+    "general": {
+      "patterns": [
+        {
+          "name": "variable.function.ds",
+          "match": "^print|^\\s+print"
+        },
+        {
+          "name": "variable.parameter.ds",
+          "match": "captioned"
+        },
+        {
+          "name": "storage.type.ds",
+          "match": "(centered to entity)|(to entity)|(at level)"
+        },
+        {
+          "name": "variable.function.ds",
+          "match": "^(playsong)|^\\s+(playsong)"
+        },
+        {
+          "name": "variable.function.ds",
+          "match": "^(play sound)|^\\s+(play sound)"
+        },
+        {
+          "name": "storage.type.ds",
+          "match": "\\b(for entity|on channel|at volume|at attenuation|after)\\b"
+        },
+        {
+          "name": "variable.parameter.ds",
+          "match": "\\b(enable|disable)\\b"
+        },
+        {
+          "name": "storage.type.ds",
+          "match": "\\b(cinematics|ambient sounds|plague skins|trigger entity)\\b"
+        },
+        {
+          "name": "variable.function.ds",
+          "match": "^(cache)|^\\s+(cache)"
+        },
+        {
+          "name": "variable.function.ds",
+          "match": "\\b(sound|roff|strings)\\b"
+        },
+        {
+          "name": "variable.function.ds",
+          "match": "^(unload)|^\\s+(unload)"
+        },
+        {
+          "name": "variable.function.ds",
+          "match": "^(setcvar cvar)|^\\s+(setcvar cvar)"
+        },
+        {
+          "name": "variable.function.ds",
+          "match": "\\b(to)\\b"
+        },
+        {
+          "name": "variable.function.ds",
+          "match": "^(run console command)|^\\s+(run console command)"
+        }
+      ]
+    },
+    "entity": {
+      "patterns": [
+        {
+          "name": "variable.function.ds",
+          "match": "^\\b(remove entity|use entity|reset ai for entity)\\b|^\\s+\\b(remove entity|use entity|reset ai for entity)\\b"
+        },
+        {
+          "name": "variable.function.ds",
+          "match": "^\\b(move entity|rotate entity)\\b|^\\s+\\b(move entity|rotate entity)\\b"
+        },
+        {
+          "name": "storage.type.ds",
+          "match": "\\b(to|by|signaling)\\b"
+        },
+        {
+          "name": "variable.function.ds",
+          "match": "\\b(at\\s)\\b"
+        },
+        {
+          "name": "storage.type.ds",
+          "match": "\\sspeed|\\sseconds"
+        },
+        {
+          "name": "variable.function.ds",
+          "match": "\\b(over\\s)\\b"
+        },
+        {
+          "name": "variable.function.ds",
+          "match": "^\\b(moverotate entity)\\b|^\\s+\\b(moverotate entity)\\b"
+        },
+        {
+          "name": "storage.type.ds",
+          "match": "\\b(from file|at|speed|signaling)\\b"
+        },
+        {
+          "name": "variable.function.ds",
+          "match": "^(animate entity)|^\\s+(animate entity)"
+        },
+        {
+          "name": "storage.type.ds",
+          "match": "\\b(showing emotion|performing action|targeting entity|repeating for|holding for|by moving|by turning|from source entity)\\b"
+        },
+        {
+          "name": "storage.type.ds",
+          "match": "\\b(nulltarget|times)\\b"
+        },
+        {
+          "name": "variable.function.ds",
+          "match": "^(copy player attributes from entity)|^\\s+(copy player attributes from entity)"
+        },
+        {
+          "name": "storage.type.ds",
+          "match": "\\b(to entity)\\b"
+        },
+        {
+          "name": "variable.function.ds",
+          "match": "^(set view angles of entity)|^\\s+(set view angles of entity)"
+        },
+        {
+          "name": "variable.function.ds",
+          "match": "^(set cache size to)|^\\s+(set cache size to)"
+        },
+        {
+          "name": "variable.function.ds",
+          "match": "^\\b(helicopter entity|tank entity)\\b|^\\s+\\b(helicopter entity|tank entity)\\b"
+        }
+      ]
+    },
+    "function": {
+      "patterns": [
+        {
+          "name": "variable.ds",
+          "match": "([a-zA-Z]+(?:_)+\\w+)|([a-zA-Z]+\\w+)"
+        },
+        {
+          "name": "keyword.operator.ds",
+          "match": "(\\.)|(\\=)|(\\-)|(\\*)|(\\+)|(\\<)|(\\>)|(\\!)|(\\/)|(,)"
+        },
+        {
+          "name": "storage.type.ds",
+          "match": "\\b(spawn entity with fields|random from|to|find entity player|find entity with targetname|find entity with scripttarget|sin|cos|get entity other|get entity activator|get entity player|entity)\\b"
+        },
+        {
+          "name": "string.ds",
+          "match": "([a-zA-Z]+(?:_)+\\w+)|([a-zA-Z]+\\w+)"
+        }
+      ]
+    },
+    "defined": {
+      "patterns": [
+        {
+          "name": "string.ds",
+          "match": "(?x)\\b(CHAN_AUTO|CHAN_WEAPON|CHAN_VOICE|CHAN_ITEM|CHAN_BODY|CHAN_ENT1|CHAN_ENT2|CHAN_NO_PHS_ADD|CHAN_RELIABLE|PRINT_LOW|PRINT_MEDIUM|PRINT_HIGH|PRINT_CHAT|MOVETYPE_NONE|MOVETYPE_NOCLIP|MOVETYPE_PUSH|MOVETYPE_STOP|MOVETYPE_WALK|MOVETYPE_STEP|MOVETYPE_FLY|MOVETYPE_TOSS|MOVETYPE_FLYMISSILE|MOVETYPE_BOUNCE|MOVETYPE_DAN|EMOTION_NORMAL|EMOTION_FEAR|EMOTION_ANGRY|EMOTION_PAIN|EMOTION_DEAD|EMOTION_TALK|EMOTION_TALKANGRY|EMOTION_TALKAFRAID|UNKNOWN|RUN|JUMP|DEATH|DEATHTHROWN|DUCK_DN|DUCK_MID|DUCK_UP|DUCK_SHOOT|IDLE|IDLESTRETCH|IDLELOOK|SHOOT|WALK|AFRAIDRUN|GUN_IDLE|SOLID_NOT|SOLID_SOLID|SOLID_BSP|DAMAGE_NO|DAMAGE_YES|DAMAGE_AIM|DAMAGE_NO_RADIUS|HELI_TAKEOFF|HELI_LAND|HELI_REPAIR|HELI_REARM|HELI_GOTO_COORDS|HELI_GOTOREL_ENTITY|HELI_GOTOREL_ENT_X|HELI_GOTOREL_ENT_Y|HELI_GOTOREL_ENT_Z|HELI_MOVEREL|HELI_PAUSE|HELI_FACE_RELENT|HELI_FACE_ABSCOORDS|HELI_FACE_ABSDIR|HELI_FACE_RELCOORDS|HELI_PILOT_FACERELENT|HELI_PILOT_FACERELCOORDS|HELI_PILOT_FACEABSCOORDS|HELI_GUNNER_FACERELENT|HELI_GUNNER_FACERELCOORDS|HELI_GUNNER_FACEABSCOORDS|HELI_STRAFE_RT|HELI_STRAFE_LT|HELI_ROCKETS_ENABLE|HELI_ROCKETS_DISABLE|HELI_CHAINGUN_ENABLE|HELI_CHAINGUN_DISABLE|HELI_FIREAT_RELENT|HELI_FIREAT_ABSCOORDS|HELI_FIREAT_RELCOORDS|HELI_AUTOFIRE_ON|HELI_AUTOFIRE_OFF|HELI_HOVER_PASSIVE|HELI_HOVER_AGGRESSIVE|HELI_SET_WORLDMINS|HELI_SET_WORLDMAXS|HELI_SET_MAXHEALTH|HELI_SET_HEALTH|HELI_SET_DEATHDEST|HELI_SET_TRACEDIMS|HELI_AI|HELI_WAYPOINT|HELI_VOLUME|HELI_VOLUMEMINS|HELI_VOLUMEMAXS|HELI_DEBUG|HELI_CHANGE_SKIN|HELI_CHANGE_BODY|HELI_OUT_OF_CONTROL|TANK_GOTOCOORDS|TANK_FIRECANNONATCOORDS|TANK_MACHGUNAUTO|TANK_DIE|TANK_AIMTURRET|HEAD|NECK|LSHOULDER|RSHOULDER|CHEST|GUT|GROIN|GUNHAND|NUG_O_POPPIN)\\b"
+        },
+        {
+          "name": "variable.parameter.ds",
+          "match": "\\b(kill)\\b"
+        },
+        {
+          "name": "constant.language.ds",
+          "match": "\\b(SCRIPT_RELEASE)\\b"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.ds",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.ds",
+              "match": "\"\""
+            }
+          ]
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "keyword.punctuation.definition.keyword.ds",
+          "match": "(\\-)"
+        },
+        {
+          "name": "constant.numeric.ds",
+          "match": "(?x)(?:(?:\\b\\d(?:[\\d']*\\d)?\\.\\d(?:[\\d']*\\d)?|\\B\\.\\d(?:[\\d']*\\d)?)(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)?(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b|(?:\\b\\d(?:[\\d']*\\d)?\\.)(?:\\B|(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))\\b|(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b\\d(?:[\\d']*\\d)?(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b(?:(?:[1-9](?:[\\d']*\\d)?|0(?:[0-7']*[0-7])?|0[Xx][\\da-fA-F](?:[\\da-fA-F']*[\\da-fA-F])?|0[Bb][01](?:[01']*[01])?)(?:(?:l{1,2}|L{1,2})[uU]?|[uU](?:l{0,2}|L{0,2})|(?:i[fl]?|h|min|[mun]?s|_\\w*))?)\\b)"
+        }
       ]
     }
   }
 }
-
-

--- a/sof-vscode-syntax/syntaxes/func.tmLanguage.json
+++ b/sof-vscode-syntax/syntaxes/func.tmLanguage.json
@@ -1,51 +1,153 @@
 {
   "scopeName": "source.func",
   "name": "SoF - SoFPlus Function",
+  "firstLineMatch": "\\b.*function *._init\\b",
   "patterns": [
     { "include": "#comment" },
-    { "include": "#strings" },
-    { "include": "#numbers" },
-    { "include": "#macro" },
-    { "include": "#keywords" },
+    { "include": "#function" },
     { "include": "#commands" }
   ],
   "repository": {
     "comment": {
-      "patterns": [{ "name": "comment.line.double-slash.func", "match": "//.*$" }]
-    },
-    "strings": {
       "patterns": [
-        { "name": "string.quoted.double.func", "begin": "\"", "end": "\"" }
+        {
+          "name": "comment.line.double-slash.func",
+          "begin": "//",
+          "end": "$",
+          "patterns": [
+            {
+              "name": "comment.func",
+              "match": ".*"
+            }
+          ]
+        }
       ]
     },
-    "macro": {
+    "function": {
       "patterns": [
-        { "name": "constant.character.escape.func", "match": "[#$]" },
-        { "name": "variable.parameter.func", "match": "~" }
-      ]
-    },
-    "numbers": {
-      "patterns": [
-        { "name": "constant.numeric.func", "match": "(?:\\b\\d+\\.\\d+|\\B\\.\\d+|\\b\\d+)(?:[Ee][+-]?\\d+)?" }
-      ]
-    },
-    "keywords": {
-      "patterns": [
-        { "name": "keyword.control.func", "match": "(?<!~)\\b(?:sp_sc_flow_if|sp_sc_flow_while|else)\\b" },
-        { "name": "keyword.other.func", "match": "\\bfunction\\b" }
+        {
+          "name": "keyword.func",
+          "match": "function",
+          "captures": {
+            "0": { "name": "keyword.func" }
+          }
+        },
+        {
+          "name": "entity.name.function.func",
+          "match": "\\b(.*\\w+$)|(.*?)(?=\\()\\b"
+        },
+        {
+          "name": "keyword.control.func",
+          "match": "(?<!~)\\b(sp_sc_flow_if|sp_sc_flow_while|else)\\b"
+        },
+        {
+          "name": "constant.other.func",
+          "match": "\\b(number|text|itext)\\b"
+        },
+        {
+          "name": "invalid.deprecated.func",
+          "match": "\\b(\\sN\\s+.?|\\sn\\s+.?|\\sT\\s+.?|\\st\\s+.?|\\sTI\\s+.?|\\sti\\s+.?)\\b"
+        },
+        {
+          "name": "string.meta.string.func",
+          "match": "\\b(cvar|val)\\b"
+        },
+        {
+          "name": "keyword.operator.func",
+          "match": "\\s(\\>|\\<|\\>=|\\<=|==|!=|=)\\s"
+        }
       ]
     },
     "commands": {
       "patterns": [
-        { "name": "keyword.other.func", "match": "(?<!~)\\b(?:wait|stop|stopsound|return|menuoff|popmenu|refresh|killmenu)\\b" },
-        { "name": "string.unquoted.command.func", "match": "(?x)(?<!~)\\b(?:path|help|info|kill|cpuid|elbow|ninja|pause|score|skins|reload|status|cmdlist|entlist|heretic|ip_list|loading|newsave|phantom|players|vid_front|vid_restart|rawshot|viewpos|z_stats|bigelbow|bindlist|changing|cl_touch|conchars|cvarlist|hackteam|itemdrop|itemnext|itemprev|precache|filter_write|clear|sizeup|sizedown|minimise|usermisc|weapnext|weapprev|itemuse|ff_usejoy|freshgame|heartbeat|imagelist|playlevel|quickload|quicksave|reconnect|reloadall|savesleft|soundinfo|soundlist|unbindall|useritems|savekeys|teamview|userammo|userinfo|getgamestats|putaway|vid_modes|centerview|disconnect|gl_strings|killserver|listignore|playerlist|saveconfig|screenshot|serverinfo|serverstop|togglechat|weapondrop|weaponlose|destroyents|ff_usemouse|filter_list|gsc_connect|listpickups|pingservers|reset_predn|snd_restart|updateinven|userweapons|hackkillbots|list_dmflags|toggleconsole|defaultweapons|gsc_disconnect|maxfpsfromrate|updateinvfinal|weaponbestsafe|gsc_getchannels|killallmonsters|givemoretutorial|turnonmissionmsg|weaponbestunsafe|turnoffmissionmsg|givesnipertutorial|joy_advancedupdateexit)\\b" },
-        { "name": "keyword.other.func", "match": "(?<!~)\\b(?:error|quit|exit|wipe)\\b" },
-        { "name": "keyword.other.func", "match": "(?<!~)\\b(?:rcon)\\b" },
-        { "name": "variable.function.func", "match": "(?<!~)\\b(?:bind|unbind|set|sset|setenv)\\b" },
-        { "name": "keyword.operator.semicolon.func", "match": ";" }
+        {
+          "name": "keyword.other.func",
+          "match": "(?<!~)\\b(wait|stop|stopsound|return|menuoff|popmenu|refresh|killmenu)\\b"
+        },
+        {
+          "name": "string.unquoted.command.func",
+          "match": "(?x)(?<!~)\\b(path|help|info|kill|cpuid|elbow|ninja|pause|score|skins|reload|status|cmdlist|entlist|heretic|ip_list|loading|newsave|phantom|players|vid_front|vid_restart|rawshot|viewpos|z_stats|bigelbow|bindlist|changing|cl_touch|conchars|cvarlist|hackteam|itemdrop|itemnext|itemprev|precache|filter_write|clear|sizeup|sizedown|minimise|usermisc|weapnext|weapprev|itemuse|ff_usejoy|freshgame|heartbeat|imagelist|playlevel|quickload|quicksave|reconnect|reloadall|savesleft|soundinfo|soundlist|unbindall|useritems|savekeys|teamview|userammo|userinfo|getgamestats|putaway|vid_modes|centerview|disconnect|gl_strings|killserver|listignore|playerlist|saveconfig|screenshot|serverinfo|serverstop|togglechat|weapondrop|weaponlose|destroyents|ff_usemouse|filter_list|gsc_connect|listpickups|pingservers|reset_predn|snd_restart|updateinven|userweapons|hackkillbots|list_dmflags|toggleconsole|defaultweapons|gsc_disconnect|maxfpsfromrate|updateinvfinal|weaponbestsafe|gsc_getchannels|killallmonsters|givemoretutorial|turnonmissionmsg|weaponbestunsafe|turnoffmissionmsg|givesnipertutorial|joy_advancedupdateexit)\\b"
+        },
+        {
+          "name": "keyword.other.func",
+          "match": "(?<!~)\\b(error|quit|exit|wipe)\\b"
+        },
+        {
+          "name": "keyword.other.func",
+          "match": "(?<!~)\\b(rcon)\\b"
+        },
+        {
+          "name": "keyword.control.func",
+          "match": "(?<!~)\\b(cmd)\\b"
+        },
+        {
+          "name": "variable.function.func",
+          "match": "(?<!~)\\b(bind|unbind|set|sset|setenv|echo|say|set_dmflags|unset_dmflags|subliminal)\\b"
+        },
+        {
+          "name": "variable.function.func",
+          "match": "(?x)(?<!~)\\b(or|xor|and|zero|map|add|dir|go|avi|sky|kick|load|menu|ping|play|save|wave|link|cloud|gimme|ignore|record|messagemode|select|addfave|bot_add|bot_rem|condump|connect|demomap|fx_load|fx_save|gamemap|gsc_ban|remfave|filter_add|adddownload|loadpoint|ff_tension|forcesong|winstart|checkpass|changepass|terrain|dumpuser|gsc_join|gsc_private|gsc_setusermode|gsc_kick|gsc_part|gsc_talk|Say_team|say_team|unignore|ff_spring|intermission|messagemode2|serverrecord|serverstatus|weaponselect|filter_remove|gsc_gettopic|gsc_getusers|gsc_settopic|sv_precache|timerefresh|alias)\\b"
+        },
+        {
+          "name": "variable.function.func",
+          "match": "(?x)(?<!~)\\b(sp_sc_alias|sp_sc_cvar_append|sp_sc_cvar_append_newline|sp_sc_cvar_big_text|sp_sc_cvar_copy|sp_sc_cvar_copy_latched|sp_sc_cvar_escape|sp_sc_cvar_math_abs|sp_sc_cvar_math_add|sp_sc_cvar_math_ceil|sp_sc_cvar_math_div|sp_sc_cvar_math_floor|sp_sc_cvar_math_mod|sp_sc_cvar_math_mul|sp_sc_cvar_math_sqrt|sp_sc_cvar_math_sub|sp_sc_cvar_nbsp|sp_sc_cvar_no_color|sp_sc_cvar_random_float|sp_sc_cvar_random_int|sp_sc_cvar_split|sp_sc_cvar_sset|sp_sc_cvar_substr|sp_sc_cvar_unescape|sp_sc_cvar_unhex|sp_sc_cvar_hex|sp_sv_client_cvar_set|sp_sc_cvar_len|sp_sc_info_net|sp_sc_info_net_reset|sp_sc_info_time|sp_sc_uptime|sp_sv_client_check|sp_sv_info_client|sp_sv_info_client_mod|sp_sv_info_frames|sp_sv_players|sp_sv_print_broadcast|sp_sv_print_client|sp_sv_print_sp_broadcast|sp_sv_print_sp_client|sp_sv_sound_broadcast|sp_sv_sound_client|sp_cl_info_map|sp_cl_info_pos|sp_cl_info_skins|sp_cl_debuggraph|tgashot)\\b"
+        },
+        {
+          "name": "variable.function.func",
+          "match": "(?x)(?<!~)\\b(sf_sv_ent_use|sf_sv_hook_at|sf_sv_int_add|sf_sv_math_or|sf_sv_ent_anim|sf_sv_ent_find|sf_sv_ent_tint|sf_sv_math_and|sf_sv_math_cos|sf_sv_math_not|sf_sv_math_sin|sf_sv_math_tan|sf_sv_print_cinprintf|sf_sv_ent_spawn|sf_sv_ent_vects|sf_sv_math_acos|sf_sv_math_asin|sf_sv_math_atan|sf_sv_check_reso|sf_sv_draw_clear|sf_sv_ent_create|sf_sv_ent_relink|sf_sv_ent_model|sf_sv_sound_remove|sf_sv_ent_remove|sf_sv_ghoul_list|sf_sv_image_list|sf_sv_player_ent|sf_sv_player_pos|sf_sv_script_run|sf_sv_sound_list|sf_sv_vector_set|sf_sv_draw_string|sf_sv_effect_list|sf_sv_ghoul_scale|sf_sv_player_anim|sf_sv_player_move|sf_sv_script_load|sf_sv_sofree_help|sf_sv_vector_copy|sf_sv_vector_grow|sf_sv_draw_string2|sf_sv_effect_start|sf_sv_ent_callback|sf_sv_mem_read_int|sf_sv_ent_paint|sf_sv_effect_endpos|sf_sv_ent_field_get|sf_sv_ent_field_set|sf_sv_mem_read_char|sf_sv_mem_write_int|sf_sv_player_effect|sf_sv_print_bprintf|sf_sv_print_cprintf|sf_sv_mem_write_string|sf_sv_jmp_at|sf_sv_draw_altstring|sf_sv_ghoul_register|sf_sv_image_register|sf_sv_mem_read_float|sf_sv_mem_read_short|sf_sv_mem_write_char|sf_sv_player_gravity|sf_sv_sound_override|sf_sv_sound_play_ent|sf_int_add|sf_sv_sound_register|sf_sv_effect_register|sf_sv_ghoul_translate|sf_sv_mem_read_string|sf_sv_mem_write_float|sf_sv_mem_write_short|sf_sv_configstring_set|sf_sv_spackage_register|sf_sv_player_paint|sf_sv_player_collision|sf_sv_player_weap_lock|sf_sv_player_allow_walk|sf_sv_player_weap_paint|sf_sv_print_centerprint|sf_sv_sound_play_origin|sf_sv_spackage_print_id|sf_sv_player_allow_altattack|sf_sv_player_weap_switch|sf_sv_print_welcomeprint|sf_sv_spackage_print_ref|sf_sv_player_allow_attack|sf_sv_player_weap_current|sf_sv_spackage_print_obit|sf_sv_spackage_print_string|sf_sv_script_unload|sf_sv_trigger_set_size|sp_sv_ent_create|sp_sv_trigger_set_size|sf_sv_info_client|sf_sv_save_reso)\\b"
+        },
+        {
+          "name": "keyword.operator.func",
+          "match": "(\\!)|(\\+)|(\\-)"
+        },
+        {
+          "name": "keyword.control.semicolon.func",
+          "match": ";"
+        }
+      ]
+    },
+    "macroexpand": {
+      "patterns": [
+        {
+          "name": "constant.character.escape.func",
+          "match": "(\\$)|(\\#)"
+        }
+      ]
+    },
+    "localvar": {
+      "patterns": [
+        {
+          "name": "variable.parameter.func",
+          "match": "(\\~)(?=\\s)|(\\~)"
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "keyword.punctuation.definition.keyword.func",
+          "match": "(\\s\\-)|(\\s\\+)"
+        },
+        {
+          "name": "constant.numeric.func",
+          "match": "(?x)(?:(?:\\b\\d(?:[\\d']*\\d)?\\.\\d(?:[\\d']*\\d)?|\\B\\.\\d(?:[\\d']*\\d)?)(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)?(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b|(?:\\b\\d(?:[\\d']*\\d)?\\.)(?:\\B|(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))\\b|(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b\\d(?:[\\d']*\\d)?(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b(?:(?:[1-9](?:[\\d']*\\d)?|0(?:[0-7']*[0-7])?|0[Xx][\\da-fA-F](?:[\\da-fA-F']*[\\da-fA-F])?|0[Bb][01](?:[01']*[01])?)(?:(?:l{1,2}|L{1,2})[uU]?|[uU](?:l{0,2}|L{0,2})|(?:i[fl]?|h|min|[mun]?s|_\\w*))?)\\b)"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.func",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.func",
+              "match": "\"\""
+            }
+          ]
+        }
       ]
     }
   }
 }
-
-

--- a/sof-vscode-syntax/syntaxes/gbm.tmLanguage.json
+++ b/sof-vscode-syntax/syntaxes/gbm.tmLanguage.json
@@ -2,12 +2,50 @@
   "scopeName": "source.gbm",
   "name": "SoF - Ghoul Bolton Model",
   "patterns": [
+    { "include": "#strings" },
     { "include": "#numbers" },
-    { "name": "string.unquoted.gbm", "match": ".+" }
+    { "include": "#keywords" }
   ],
   "repository": {
-    "numbers": { "patterns": [ { "name": "constant.numeric.gbm", "match": "\\b\\d+\\b" } ] }
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.gbm",
+          "match": "(.+$\\n)|(.+)"
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.gbm",
+          "match": "[0-9]+"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "entity.name.gbm",
+          "match": ".+$\\n"
+        },
+        {
+          "name": "variable.function.gbm",
+          "match": ".+$\\n"
+        },
+        {
+          "name": "keyword.gbm",
+          "match": "(^[\\s]*\\n)|(.)"
+        },
+        {
+          "name": "keyword.gbm",
+          "match": "((\\w+\\s)(\\w+\\s))"
+        },
+        {
+          "name": "keyword.gbm",
+          "match": "(\\{\\})"
+        }
+      ]
+    }
   }
 }
-
-

--- a/sof-vscode-syntax/syntaxes/gin.tmLanguage.json
+++ b/sof-vscode-syntax/syntaxes/gin.tmLanguage.json
@@ -1,24 +1,172 @@
 {
   "scopeName": "source.gin",
   "name": "SoF - GIN",
+  "firstLineMatch": "(^File:)",
   "patterns": [
+    { "include": "#comment" },
     { "include": "#numbers" },
-    { "name": "keyword.other.gin", "match": "^File:" },
-    { "name": "keyword.other.gin", "match": "^3DSMax BBox Min:" },
-    { "name": "keyword.other.gin", "match": "^3DSMax BBox Max:" },
-    { "name": "keyword.other.gin", "match": "^Sequence" },
-    { "name": "keyword.other.gin", "match": "^Frame Time" },
-    { "name": "keyword.other.gin", "match": "^NoteKeys:" },
-    { "name": "keyword.other.gin", "match": "^StartFrame" },
-    { "name": "keyword.other.gin", "match": "^Materials" },
-    { "include": "#strings" }
+    { "include": "#keywords" },
+    { "include": "#strings" },
+    { "include": "#materials" }
   ],
   "repository": {
-    "numbers": { "patterns": [ { "name": "constant.numeric.gin", "match": "(?:[=+\-])|(?:\\b\\d+\\.\\d+|\\B\\.\\d+|\\b\\d+)(?:[Ee][+-]?\\d+)?" } ] },
+    "comment": {
+      "patterns": [
+        {
+          "name": "comment.line.double-slash.gin",
+          "begin": "//",
+          "end": "$",
+          "patterns": [
+            {
+              "name": "comment.gin",
+              "match": ".*"
+            }
+          ]
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "keyword.gin",
+          "match": "(\\=)|(\\+)|(\\-)"
+        },
+        {
+          "name": "constant.numeric.gin",
+          "match": "(?x)(?:(?:\\b\\d(?:[\\d']*\\d)?\\.\\d(?:[\\d']*\\d)?|\\B\\.\\d(?:[\\d']*\\d)?)(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)?(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b|(?:\\b\\d(?:[\\d']*\\d)?\\.)(?:\\B|(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))\\b|(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b\\d(?:[\\d']*\\d)?(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b(?:(?:[1-9](?:[\\d']*\\d)?|0(?:[0-7']*[0-7])?|0[Xx][\\da-fA-F](?:[\\da-fA-F']*[\\da-fA-F])?|0[Bb][01](?:[01']*[01])?)(?:(?:l{1,2}|L{1,2})[uU]?|[uU](?:l{0,2}|L{0,2})|(?:i[fl]?|h|min|[mun]?s|_\\w*))?)\\b)"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.gin",
+          "match": "(^File:)"
+        },
+        {
+          "name": "entity.name.gin",
+          "match": ".*$\\n"
+        },
+        {
+          "name": "keyword.gin",
+          "match": "(^3DSMax BBox Min:)"
+        },
+        {
+          "name": "entity.name.gin",
+          "match": "\\("
+        },
+        {
+          "name": "keyword.gin",
+          "match": "\\,"
+        },
+        {
+          "name": "entity.name.gin",
+          "match": "\\)$\\n"
+        },
+        {
+          "name": "keyword.gin",
+          "match": "(^3DSMax BBox Max:)"
+        },
+        {
+          "name": "entity.name.gin",
+          "match": "\\)"
+        },
+        {
+          "name": "keyword.gin",
+          "match": "(^Sequence)"
+        },
+        {
+          "name": "keyword.gin",
+          "match": "(^Frame Time)"
+        },
+        {
+          "name": "keyword.gin",
+          "match": "(^NoteKeys:)"
+        },
+        {
+          "name": "variable.function.gin",
+          "match": "(time)|(token)|(rest)"
+        },
+        {
+          "name": "keyword.gin",
+          "match": "(^StartFrame)"
+        },
+        {
+          "name": "keyword.gin",
+          "match": "(NumFrames)"
+        },
+        {
+          "name": "keyword.gin",
+          "match": "(^Materials)"
+        },
+        {
+          "name": "keyword.gin",
+          "match": "(^Nulls:)|(^Meshes:)|(^Cameras:)"
+        },
+        {
+          "name": "keyword.gin",
+          "match": "(^Lights:)"
+        },
+        {
+          "name": "storage.type.gin",
+          "match": "(?x)\\b(Non-Blob Size|Blob Size|verts|nulls|Mat Blocks|cPos|cTex|cNorm|Mesh|Elem|Corn|aPos|aTex|aNorm|Comp)\\b"
+        }
+      ]
+    },
     "strings": {
-      "patterns": [ { "name": "string.quoted.double.gin", "begin": "\"", "end": "\"" } ]
+      "patterns": [
+        {
+          "name": "string.quoted.double.gin",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.gin",
+              "match": "\"\""
+            }
+          ]
+        }
+      ]
+    },
+    "materials": {
+      "patterns": [
+        {
+          "name": "keyword.gin",
+          "match": "\\s+(Name)"
+        },
+        {
+          "name": "entity.name.gin",
+          "match": "(.*)"
+        },
+        {
+          "name": "variable.function.gin",
+          "match": "(opaque)|(specular)|(tex)|(two sided)|(additive)|(Animates:)"
+        },
+        {
+          "name": "keyword.gin",
+          "match": "no"
+        },
+        {
+          "name": "entity.name.gin",
+          "match": "yes"
+        },
+        {
+          "name": "variable.function.gin",
+          "match": "(Tex Map)"
+        },
+        {
+          "name": "variable.function.gin",
+          "match": "\\["
+        },
+        {
+          "name": "variable.function.gin",
+          "match": "\\]"
+        },
+        {
+          "name": "message.error.gin",
+          "match": "(Warning:)"
+        }
+      ]
     }
   }
 }
-
-

--- a/sof-vscode-syntax/syntaxes/gpm.tmLanguage.json
+++ b/sof-vscode-syntax/syntaxes/gpm.tmLanguage.json
@@ -1,37 +1,123 @@
 {
   "scopeName": "source.gpm",
   "name": "SoF - Ghoul Player Model",
+  "firstLineMatch": "\\b(enemy/meso|enemy/female)\\b",
   "patterns": [
     { "include": "#comment" },
-    { "include": "#strings" },
     { "include": "#numbers" },
     { "include": "#keywords" },
-    { "include": "#paths" },
-    { "include": "#misc" }
+    { "include": "#strings" }
   ],
   "repository": {
-    "comment": { "patterns": [ { "name": "comment.line.double-slash.gpm", "match": "//.*$" } ] },
-    "strings": { "patterns": [ { "name": "string.quoted.double.gpm", "begin": "\"", "end": "\"" } ] },
-    "numbers": { "patterns": [ { "name": "constant.numeric.gpm", "match": "(?:\\b\\d+\\.\\d+|\\B\\.\\d+|\\b\\d+)(?:[Ee][+-]?\\d+)?" } ] },
-    "keywords": {
+    "comment": {
       "patterns": [
-        { "name": "constant.language.gpm", "match": "\\bNoteam\\b" },
-        { "name": "keyword.gpm", "match": "\\b(?:enemy/meso|enemy/female)\\b" },
-        { "name": "keyword.gpm", "match": "\\b(?:meso_menu|fem_menu|meso_player|fem_play)\\b" },
-        { "name": "keyword.gpm", "match": "\\b(?:playerarbul|playerboss|playerbulbul|playerbulbulcoat|playerbulbulti|playerbultibul|playercalfcuff|playercoat|playermask|playersuit|playerbulti|playertiti)\\b" },
-        { "name": "entity.name.gpm", "match": "\\benemy/dth/[a-z]+\\b" }
+        {
+          "name": "comment.line.double-slash.gpm",
+          "begin": "//",
+          "end": "$",
+          "patterns": [
+            {
+              "name": "comment.gpm",
+              "match": ".*"
+            }
+          ]
+        }
       ]
     },
-    "paths": {
-      "patterns": [ { "name": "string.other.path.gpm", "match": "[A-Za-z0-9_./\\\\\\-]+\\.gbm\b" } ]
-    },
-    "misc": {
+    "numbers": {
       "patterns": [
-        { "name": "storage.type.gpm", "match": "_+\\w+" },
-        { "name": "variable.parameter.gpm", "match": "[{}]" }
+        {
+          "name": "constant.numeric.gpm",
+          "match": "(?x)(?:(?:\\b\\d(?:[\\d']*\\d)?\\.\\d(?:[\\d']*\\d)?|\\B\\.\\d(?:[\\d']*\\d)?)(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)?(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b|(?:\\b\\d(?:[\\d']*\\d)?\\.)(?:\\B|(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))\\b|(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b\\d(?:[\\d']*\\d)?(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b(?:(?:[1-9](?:[\\d']*\\d)?|0(?:[0-7']*[0-7])?|0[Xx][\\da-fA-F](?:[\\da-fA-F']*[\\da-fA-F])?|0[Bb][01](?:[01']*[01])?)(?:(?:l{1,2}|L{1,2})[uU]?|[uU](?:l{0,2}|L{0,2})|(?:i[fl]?|h|min|[mun]?s|_\\w*))?)\\b)"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.gpm",
+          "match": "\\b(enemy/meso|enemy/female)\\b"
+        },
+        {
+          "name": "keyword.gpm",
+          "match": "(meso_menu)"
+        },
+        {
+          "name": "entity.name.function.gpm",
+          "match": "[1-9]"
+        },
+        {
+          "name": "keyword.gpm",
+          "match": "(fem_menu)"
+        },
+        {
+          "name": "keyword.gpm",
+          "match": "\\b(meso_player|fem_play)\\b"
+        },
+        {
+          "name": "keyword.gpm",
+          "match": "(?x)\\b(playerarbul|playerboss|playerbulbul|playerbulbulcoat|playerbulbulti|playerbultibul|playercalfcuff|playercoat|playermask|playersuit|playerbulti|playertiti)\\b"
+        },
+        {
+          "name": "keyword.gpm",
+          "match": "\\b(enemy/dth/)\\b"
+        },
+        {
+          "name": "entity.name.gpm",
+          "match": "[a-z]+"
+        },
+        {
+          "name": "string.gpm",
+          "match": "\\w+"
+        },
+        {
+          "name": "variable.gpm",
+          "match": "\\{"
+        },
+        {
+          "name": "variable.parameter.gpm",
+          "match": "\\b(a|b|c|f|h|hd|md|gz)\\b"
+        },
+        {
+          "name": "storage.type.gpm",
+          "match": "(\\s+\\w+_+\\w+)"
+        },
+        {
+          "name": "string.gpm",
+          "match": "(.*\\.gbm)"
+        },
+        {
+          "name": "storage.type.gpm",
+          "match": "\\w+"
+        },
+        {
+          "name": "storage.type.gpm",
+          "match": "(_+\\w+)"
+        },
+        {
+          "name": "variable.gpm",
+          "match": "\\}"
+        },
+        {
+          "name": "constant.language.gpm",
+          "match": "Noteam"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.gpm",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.gpm",
+              "match": "\"\""
+            }
+          ]
+        }
       ]
     }
   }
 }
-
-

--- a/sof-vscode-syntax/syntaxes/gsq.tmLanguage.json
+++ b/sof-vscode-syntax/syntaxes/gsq.tmLanguage.json
@@ -2,10 +2,38 @@
   "scopeName": "source.gsq",
   "name": "SoF - Ghoul Sequences",
   "patterns": [
-    { "name": "keyword.other.directive.gsq", "match": "#.*$" },
-    { "name": "string.other.underscore.gsq", "match": "_" },
-    { "name": "constant.numeric.gsq", "match": "\\d+" }
-  ]
+    { "include": "#keywords" },
+    { "include": "#numbers" },
+    { "include": "#strings" }
+  ],
+  "repository": {
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.gsq",
+          "match": "\\#"
+        },
+        {
+          "name": "entity.name.gsq",
+          "match": ".+$\\n"
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.gsq",
+          "match": "\\d"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.gsq",
+          "match": "\\_"
+        }
+      ]
+    }
+  }
 }
-
-

--- a/sof-vscode-syntax/syntaxes/ifl.tmLanguage.json
+++ b/sof-vscode-syntax/syntaxes/ifl.tmLanguage.json
@@ -2,10 +2,25 @@
   "scopeName": "source.ifl",
   "name": "SoF - Image Files",
   "patterns": [
-    { "name": "keyword.ifl", "match": ".*" },
-    { "name": "constant.numeric.ifl", "match": "\\b\\d+\\b" },
-    { "name": "entity.name.filename.ifl", "match": "\\.[tT][gG][aA]$" }
-  ]
+    { "include": "#numbers" },
+    { "include": "#keywords" }
+  ],
+  "repository": {
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.ifl",
+          "match": "\\d"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "entity.name.ifl",
+          "match": "(\\.[tT][gG][aA])$\\n?"
+        }
+      ]
+    }
+  }
 }
-
-

--- a/sof-vscode-syntax/syntaxes/lst.tmLanguage.json
+++ b/sof-vscode-syntax/syntaxes/lst.tmLanguage.json
@@ -4,16 +4,71 @@
   "patterns": [
     { "include": "#comment" },
     { "include": "#strings" },
-    { "name": "string.unquoted.path.lst", "match": "^(?:\\w+\\s|\\w+\\s/).*$" },
-    { "name": "storage.type.folder.lst", "match": "^\\w+/" },
-    { "name": "invalid.deprecated.alpha.lst", "match": "(?:alpha[0-9]+|alpha|beta?[0-9]+|beta|[dD][eE][mM][oO])$" },
-    { "name": "entity.name.final.lst", "match": "final.?$" },
-    { "name": "variable.function.suffix.lst", "match": "_x$" }
+    { "include": "#keywords" },
+    { "include": "#numbers" }
   ],
   "repository": {
-    "comment": { "patterns": [ { "name": "comment.line.double-slash.lst", "match": "//.*$" } ] },
-    "strings": { "patterns": [ { "name": "string.quoted.double.lst", "begin": "\"", "end": "\"" } ] }
+    "comment": {
+      "patterns": [
+        {
+          "name": "comment.line.double-slash.lst",
+          "begin": "//",
+          "end": "$",
+          "patterns": [
+            {
+              "name": "comment.lst",
+              "match": ".*"
+            }
+          ]
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.lst",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.lst",
+              "match": "\"\""
+            }
+          ]
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "string.lst",
+          "match": "(^\\w+\\s)|(^\\w+\\s/)"
+        },
+        {
+          "name": "storage.type.lst",
+          "match": "(^\\w+/)"
+        },
+        {
+          "name": "keyword.error.lst",
+          "match": "(alpha[0-9]+)|(alpha)|(beta?[0-9]+)|(beta)|([dD][eE][mM][oO])$\\n?"
+        },
+        {
+          "name": "entity.name.lst",
+          "match": "final.?$\\n"
+        },
+        {
+          "name": "variable.function.lst",
+          "match": "_x$\\n"
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.lst",
+          "match": "(?x)(?:(?:\\b\\d(?:[\\d']*\\d)?\\.\\d(?:[\\d']*\\d)?|\\B\\.\\d(?:[\\d']*\\d)?)(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)?(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b|(?:\\b\\d(?:[\\d']*\\d)?\\.)(?:\\B|(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))\\b|(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b\\d(?:[\\d']*\\d)?(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b(?:(?:[1-9](?:[\\d']*\\d)?|0(?:[0-7']*[0-7])?|0[Xx][\\da-fA-F](?:[\\da-fA-F']*[\\da-fA-F])?|0[Bb][01](?:[01']*[01])?)(?:(?:l{1,2}|L{1,2})[uU]?|[uU](?:l{0,2}|L{0,2})|(?:i[fl]?|h|min|[mun]?s|_\\w*))?)\\b)"
+        }
+      ]
+    }
   }
 }
-
-

--- a/sof-vscode-syntax/syntaxes/qdt.tmLanguage.json
+++ b/sof-vscode-syntax/syntaxes/qdt.tmLanguage.json
@@ -2,30 +2,126 @@
   "scopeName": "source.qdt",
   "name": "SoF - SoF QData",
   "patterns": [
-    { "include": "#comments" },
+    { "include": "#comment" },
     { "include": "#numbers" },
-    { "include": "#strings" },
-    { "include": "#directives" }
+    { "include": "#keywords" },
+    { "include": "#strings" }
   ],
   "repository": {
-    "comments": {
+    "comment": {
       "patterns": [
-        { "name": "comment.line.double-slash.qdt", "match": "//.*$" },
-        { "name": "comment.line.number-sign.qdt", "match": "#.*$" },
-        { "name": "comment.line.semicolon.qdt", "match": ";.*$" },
-        { "name": "comment.block.qdt", "begin": "/\\*", "end": "\\*/" }
+        {
+          "name": "comment.line.double-slash.qdt",
+          "begin": "//",
+          "end": "$",
+          "patterns": [
+            {
+              "name": "comment.qdt",
+              "match": ".*"
+            }
+          ]
+        },
+        {
+          "name": "comment.line.number-sign.qdt",
+          "begin": "#",
+          "end": "$",
+          "patterns": [
+            {
+              "name": "comment.qdt",
+              "match": ".*"
+            }
+          ]
+        },
+        {
+          "name": "comment.line.semicolon.qdt",
+          "begin": ";",
+          "end": "$",
+          "patterns": [
+            {
+              "name": "comment.qdt",
+              "match": ".*"
+            }
+          ]
+        },
+        {
+          "name": "comment.block.qdt",
+          "begin": "/\\*",
+          "end": "\\*/",
+          "patterns": [
+            {
+              "name": "comment.qdt",
+              "match": ".*"
+            }
+          ]
+        }
       ]
     },
-    "strings": { "patterns": [ { "name": "string.quoted.double.qdt", "begin": "\"", "end": "\"" } ] },
-    "numbers": { "patterns": [ { "name": "constant.numeric.qdt", "match": "\\b\\d+(?:\\.\\d+)?\\b" } ] },
-    "directives": {
+    "numbers": {
       "patterns": [
-        { "name": "keyword.directive.qdt", "match": "^\\$\\s*(?:pak|mipdir|picdir|load|texturemix|tmixdir|file|dir|maps|include)\\b" },
-        { "name": "entity.name.function.qdt", "match": "\\bmip\\b" },
-        { "name": "support.constant.gl.qdt", "match": "\\bGL_(?:ZERO|ONE|SRC_COLOR|ONE_MINUS_SRC_COLOR|DST_COLOR|ONE_MINUS_DST_COLOR|SRC_ALPHA|ONE_MINUS_SRC_ALPHA|DST_ALPHA|ONE_MINUS_DST_ALPHA|SRC_ALPHA_SATURATE)\\b" }
+        {
+          "name": "constant.character.escape.qdt",
+          "match": "\\b([0-9]\\s+|[0-9]+(.))\\b"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.qdt",
+          "match": "^\\$"
+        },
+        {
+          "name": "entity.name.function.qdt",
+          "match": "\\b(mip\\s+)\\b"
+        },
+        {
+          "name": "variable.parameter.function.qdt",
+          "match": "\\b(\\w|-)+\\s+\\b"
+        },
+        {
+          "name": "constant.character.escape.qdt",
+          "match": "\\b(?:[\\d']*\\d)\\s+\\b(?:[\\d']*\\d)\\s+\\b(?:[\\d']*\\d)\\s+\\b(?:[\\d']*\\d)\\s+"
+        },
+        {
+          "name": "keyword.qdt",
+          "match": "(?x)\\b(pushpull|water|slime|lava|window|mist|origin|playerclip|monsterclip|hint|skip|slick|sky|warping|trans33|trans66|flowing|nodraw|alpha|undulate|skyreflect)\\b"
+        },
+        {
+          "name": "variable.function.qdt",
+          "match": "\\b(light|animspeed|anim|alt|damage|material|scale|mip|detail|spherical|m_nomip|m_detail|m_spherical|m_parental)\\b"
+        },
+        {
+          "name": "markup.italic.qdt",
+          "match": "(?x)\\b(GL_ZERO|GL_ONE|GL_SRC_COLOR|GL_ONE_MINUS_SRC_COLOR|GL_DST_COLOR|GL_ONE_MINUS_DST_COLOR|GL_SRC_ALPHA|GL_ONE_MINUS_SRC_ALPHA|GL_DST_ALPHA|GL_ONE_MINUS_DST_ALPHA|GL_SRC_ALPHA_SATURATE)\\b"
+        },
+        {
+          "name": "string.quoted.double.qdt",
+          "match": "\\w+\\.m32"
+        },
+        {
+          "name": "entity.name.function.qdt",
+          "match": "\\b(pak|mipdir|picdir|load|texturemix|tmixdir|file|dir|maps|include)\\b"
+        },
+        {
+          "name": "variable.parameter.function.qdt",
+          "match": ".*"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.qdt",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.qdt",
+              "match": "\"\""
+            }
+          ]
+        }
       ]
     }
   }
 }
-
-

--- a/sof-vscode-syntax/syntaxes/qe4.tmLanguage.json
+++ b/sof-vscode-syntax/syntaxes/qe4.tmLanguage.json
@@ -1,27 +1,102 @@
 {
-  "scopeName": "source.wrs",
+  "scopeName": "source.qe4",
   "name": "SoF - SDK Radiant project file",
   "patterns": [
     { "include": "#comment" },
     { "include": "#numbers" },
-    { "include": "#strings" },
     { "include": "#keywords" },
-    { "include": "#flags" }
+    { "include": "#strings" }
   ],
   "repository": {
-    "comment": { "patterns": [ { "name": "comment.line.double-slash.qe4", "match": "//.*$" } ] },
-    "numbers": { "patterns": [ { "name": "constant.numeric.qe4", "match": "\\b\\d+(?:\\.\\d+)?\\b" } ] },
-    "strings": { "patterns": [ { "name": "variable.language.qe4", "begin": "\"", "end": "\"" } ] },
-    "keywords": {
+    "comment": {
       "patterns": [
-        { "name": "variable.function.qe4", "match": "\\b(?:basepath|rshcmd|remotebasepath|entitypath|texturepath|autosave|mapspath|bsp_Relight_Qrad|bsp_FullVis|bsp_NoVis|bsp_Entities|bsp_VisRad|bsp_FastVis)\\b" },
-        { "name": "string.exe.qe4", "match": "\\b(?:sofarghrad|sofvis|sofbsp|\\.exe)\\b" },
-        { "name": "string.drive.qe4", "match": ".:" },
-        { "name": "keyword.operator.flag.qe4", "match": "-\\w+" }
+        {
+          "name": "comment.line.double-slash.qe4",
+          "begin": "//",
+          "end": "$",
+          "patterns": [
+            {
+              "name": "comment.qe4",
+              "match": ".*"
+            }
+          ]
+        }
       ]
     },
-    "flags": { "patterns": [ { "name": "variable.parameter.qe4", "match": "\\(.*?\\)" } ] }
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.qe4",
+          "match": "(?x)(?:(?:\\b\\d(?:[\\d']*\\d)?\\.\\d(?:[\\d']*\\d)?|\\B\\.\\d(?:[\\d']*\\d)?)(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)?(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b|(?:\\b\\d(?:[\\d']*\\d)?\\.)(?:\\B|(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))\\b|(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b\\d(?:[\\d']*\\d)?(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b(?:(?:[1-9](?:[\\d']*\\d)?|0(?:[0-7']*[0-7])?|0[Xx][\\da-fA-F](?:[\\da-fA-F']*[\\da-fA-F])?|0[Bb][01](?:[01']*[01])?)(?:(?:l{1,2}|L{1,2})[uU]?|[uU](?:l{0,2}|L{0,2})|(?:i[fl]?|h|min|[mun]?s|_\\w*))?)\\b)"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "variable.function.qe4",
+          "match": "\\b(basepath|rshcmd|remotebasepath|entitypath|texturepath|autosave|mapspath)\\b"
+        },
+        {
+          "name": "keyword.qe4",
+          "match": "\"\\s\""
+        },
+        {
+          "name": "variable.function.qe4",
+          "match": "(?x)\\b(bsp_Relight_Qrad|bsp_FullVis|bsp_NoVis|bsp_Entities|bsp_VisRad|bsp_FastVis)\\b"
+        },
+        {
+          "name": "string.qe4",
+          "match": "\\b(sofarghrad|sofvis|sofbsp|\\.exe)\\b"
+        },
+        {
+          "name": "string.qe4",
+          "match": ".:"
+        },
+        {
+          "name": "keyword.qe4",
+          "match": "\\-"
+        },
+        {
+          "name": "entity.name.qe4",
+          "match": "\\w+"
+        },
+        {
+          "name": "variable.parameter.qe4",
+          "match": "\\("
+        },
+        {
+          "name": "variable.parameter.qe4",
+          "match": "(.*?)(?=\\()"
+        },
+        {
+          "name": "variable.parameter.qe4",
+          "match": "\\)"
+        },
+        {
+          "name": "keyword.qe4",
+          "match": "(\\&&)|(\\!)|(\\$)"
+        },
+        {
+          "name": "string.qe4",
+          "match": "(\\\\)"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.qe4",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.qe4",
+              "match": "\"\""
+            }
+          ]
+        }
+      ]
+    }
   }
 }
-
-

--- a/sof-vscode-syntax/syntaxes/rmf.tmLanguage.json
+++ b/sof-vscode-syntax/syntaxes/rmf.tmLanguage.json
@@ -1,31 +1,400 @@
 {
   "scopeName": "source.rmf",
   "name": "SoF - Raven Menu Format",
+  "firstLineMatch": "<stm>",
   "patterns": [
-    { "include": "#comment" },
+    { "include": "#comments" },
     { "include": "#strings" },
-    { "include": "#numbers" },
-    { "include": "#tags" },
-    { "include": "#colors" }
+    { "include": "#control" },
+    { "include": "#layout" },
+    { "include": "#area" },
+    { "include": "#numbers" }
   ],
   "repository": {
-    "comment": { "patterns": [ { "name": "comment.line.double-slash.rmf", "match": "//.*$" } ] },
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.double-slash.rmf",
+          "begin": "//",
+          "end": "$",
+          "patterns": [
+            {
+              "name": "comment.rmf",
+              "match": ".*"
+            }
+          ]
+        }
+      ]
+    },
     "strings": {
       "patterns": [
-        { "name": "string.quoted.double.rmf", "begin": "\"", "end": "\"" },
-        { "name": "markup.heading.package.rmf", "begin": "\\^", "end": "\\^" }
+        {
+          "name": "string.quoted.double.rmf",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.rmf",
+              "match": "\"\""
+            }
+          ]
+        },
+        {
+          "name": "markup.heading.rmf",
+          "begin": "\\^",
+          "end": "\\^",
+          "patterns": [
+            {
+              "name": "string.rmf",
+              "match": ".*"
+            }
+          ]
+        }
       ]
     },
-    "numbers": { "patterns": [ { "name": "constant.numeric.rmf", "match": "(?:\\b\\d+\\.\\d+|\\B\\.\\d+|\\b\\d+)(?:[Ee][+-]?\\d+)?" } ] },
-    "tags": {
+    "control": {
       "patterns": [
-        { "name": "keyword.control.rmf", "match": "<\\s*(?:stm|frame|key|ikey|ckey|alias|set|timeout|cinclude|cninclude|einclude|exinclude|comment|includecvar|cbuf|include|config|exitcfg|tint|font|br|hbr|HBR|center|normal|left|right|cursor|defaults|translate|emote|semote|demote|autoscroll|tab|dmnames|strings|backdrop|blank|hr|vbar|users|chat|rooms|text|ctext|image|list|slider|ticker|input|popup|setkey|selection|ghoul|bghoul|gpm|filebox|filereq|loadbox|serverbox|serverdetail|players|listfile)\\b" }
+        {
+          "name": "keyword.control.rmf",
+          "match": "\\b(stm)\\b"
+        },
+        {
+          "name": "variable.function.rmf",
+          "match": "\\b(nopush|noescape|waitanim|fragile|global)\\b"
+        },
+        {
+          "name": "entity.name.rmf",
+          "match": "\\b(command|resize)\\b"
+        },
+        {
+          "name": "keyword.control.rmf",
+          "match": "(?<!\\s)\\b(frame)\\b"
+        },
+        {
+          "name": "entity.name.rmf",
+          "match": "\\b(page|cpage|cut|border|backfill)\\b"
+        },
+        {
+          "name": "variable.function.rmf",
+          "match": "\\b(center)\\b"
+        },
+        {
+          "name": "keyword.control.rmf",
+          "match": "(?<!\\s)\\b(key)\\b"
+        },
+        {
+          "name": "support.type.rmf",
+          "match": "\\b(any|ANY)\\b"
+        },
+        {
+          "name": "keyword.control.rmf",
+          "match": "(?<!\\s)\\b(ikey|ckey|alias|set|timeout)\\b"
+        },
+        {
+          "name": "variable.rmf",
+          "match": "\\w+"
+        },
+        {
+          "name": "keyword.control.rmf",
+          "match": "(?<!\\s)\\b(cinclude|cninclude|einclude|exinclude)\\b"
+        },
+        {
+          "name": "keyword.control.rmf",
+          "match": "(?<!\\s)\\b(comment)\\b"
+        },
+        {
+          "name": "keyword.control.rmf",
+          "match": "(?<!\\s)\\b(includecvar|cbuf)\\b"
+        },
+        {
+          "name": "keyword.control.rmf",
+          "match": "(?<!\\s)\\b(include|config|exitcfg)\\b"
+        }
       ]
     },
-    "colors": {
-      "patterns": [ { "name": "support.constant.color.rmf", "match": "\\b(?:vbargray|normaltext|hilitetext|backtint|tipback|tip|icontint|iconhilite|hgreen|hblue|lblue|lred|clear|black|transblack|semiblack|smokey|transgray|darkgray|gray|white|orange|red|blue|green|purple|cyan|header|yellow)\\b" } ]
+    "layout": {
+      "patterns": [
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(tint)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(font)\\b"
+        },
+        {
+          "name": "entity.name.rmf",
+          "match": "\\b(tint|atint|type)\\b"
+        },
+        {
+          "name": "support.type.rmf",
+          "match": "\\b(small|medium|title|interface)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(br|hbr|HBR|center|normal|left|right)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(cursor)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(defaults)\\b"
+        },
+        {
+          "name": "entity.name.rmf",
+          "match": "\\b(noborder|border|tiptint|tipbtint|tipfont)\\b"
+        },
+        {
+          "name": "support.type.rmf",
+          "match": "\\b(small|medium|title)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(translate)\\b"
+        },
+        {
+          "name": "entity.name.rmf",
+          "match": "\\b(conv|convbits)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(emote|semote|demote)\\b"
+        },
+        {
+          "name": "constant.character.escape.rmf",
+          "match": "(\\%n)|(\\%p)"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(autoscroll|tab)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(dmnames)\\b"
+        },
+        {
+          "name": "entity.name.rmf",
+          "match": "\\b(Standard|Assassin|Arsenal|CTF|Realistic)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(strings)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(backdrop)\\b"
+        },
+        {
+          "name": "variable.function.rmf",
+          "match": "\\b(tile|stretch|center|left|right|bgcolor|global)\\b"
+        }
+      ]
+    },
+    "area": {
+      "patterns": [
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(blank)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(hr|vbar|users|chat|rooms)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(text|ctext)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(image)\\b"
+        },
+        {
+          "name": "entity.name.rmf",
+          "match": "\\b(setimage|text|cvartext|abs|scale|alt|hflip|vflip|transient)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(list)\\b"
+        },
+        {
+          "name": "entity.name.rmf",
+          "match": "\\b(atext|match|bitmask|files)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(slider)\\b"
+        },
+        {
+          "name": "entity.name.rmf",
+          "match": "\\b(min|max|step|vertical|horizontal|bar|button|cap)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(ticker)\\b"
+        },
+        {
+          "name": "entity.name.rmf",
+          "match": "\\b(speed|delay)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(input)\\b"
+        },
+        {
+          "name": "entity.name.rmf",
+          "match": "\\b(global|hidden|history|maxchars)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(popup)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(setkey)\\b"
+        },
+        {
+          "name": "entity.name.rmf",
+          "match": "\\b(atext|talign)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(selection)\\b"
+        },
+        {
+          "name": "entity.name.rmf",
+          "match": "\\b(weapons|items|ammo|misc)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(ghoul|bghoul)\\b"
+        },
+        {
+          "name": "entity.name.rmf",
+          "match": "\\b(control|oneshot|yaw|pitch|roll|scale|time|animate|rotate|totation|mousex|mousey|gbolt|bgbolt|end)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(gpm)\\b"
+        },
+        {
+          "name": "entity.name.rmf",
+          "match": "\\b(cvar2|scale|rotate)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(filebox|filereq)\\b"
+        },
+        {
+          "name": "entity.name.rmf",
+          "match": "\\b(sort|backfill|talign)\\b"
+        },
+        {
+          "name": "markup.heading.rmf",
+          "match": "\\b(name|rname|size|rsize|time|rtime)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(loadbox)\\b"
+        },
+        {
+          "name": "entity.name.rmf",
+          "match": "\\b(spacing|saving)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "(?<!\\s)\\b(serverbox)\\b"
+        },
+        {
+          "name": "entity.name.rmf",
+          "match": "\\b(column|hostname|address|dnames)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "\\b(serverdetail|players)\\b"
+        },
+        {
+          "name": "entity.name.rmf",
+          "match": "\\b(title)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "\\b(listfile)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "\\b(hbar)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "\\b(bot|botlist)\\b"
+        },
+        {
+          "name": "keyword.rmf",
+          "match": "\\b(onexit)\\b"
+        }
+      ]
+    },
+    "area_key": {
+      "patterns": [
+        {
+          "name": "variable.function.rmf",
+          "match": "\\b(key|ikey|ckey|atext|tab|width|height|cvar|cvari|inc|mod|tip|xoff|yoff|tint|atint|btint|ctint|dtint|bolt|bbolt|align|border)\\b"
+        },
+        {
+          "name": "keyword.control.rmf",
+          "match": "\\b(iflt|ifle|ifge|ifeq|ifset|ifclr|ifne|ifgt)\\b"
+        },
+        {
+          "name": "variable.function.rmf",
+          "match": "\\b(regular|invisible|noshade|noborder|noscale)\\b"
+        }
+      ]
+    },
+    "mousekey": {
+      "patterns": [
+        {
+          "name": "markup.heading.rmf",
+          "match": "\\b(any|ANY)\\b"
+        },
+        {
+          "name": "markup.bold.rmf",
+          "match": "(?x)\\b(1|2|3|4|5|6|7|8|9|0|a|b|c|d|e|f|g|h|i|j|k|l|m|n|o|p|q|r|s|t|u|v|w|x|y|z|tab|enter|escape|space|backspace|uparrow|leftarrow|rightarrow|downarrow|lalt|ralt|lctrl|rctrl|lshift|rshift|f1|f2|f3|f4|f5|f6|f7|f8|f9|f10|f11|f12|ins|del|pgdn|pgup|home|end|mouse1|mouse2|mouse3|mouse4|mouse5|mouse1dbl|mouse2dbl|mouse3dbl|mouse4dbl|mouse5dbl|joy1|joy2|joy3|joy4|aux1|aux2|aux3|aux4|aux5|aux6|aux7|aux8|aux9|aux10|aux11|aux12|aux13|aux14|aux15|aux16|aux17|aux18|aux19|aux20|aux21|aux22|aux23|aux24|aux25|aux26|aux27|aux28|aux29|aux30|aux31|aux32|kp_home|kp_uparrow|kp_pgup|kp_leftarrow|kp_5|kp_rightarrow|kp_end|kp_downarrow|kp_pgdn|kp_enter|kp_ins|kp_del|kp_fslash|kp_star|kp_minus|kp_plus|mwheelup|mwheeldown|pause|semicolon|caps|kp_scroll|kp_numlock|A|B|C|D|E|F|G|H|I|J|K|L|M|N|O|P|Q|R|S|T|U|V|W|X|Y|Z|TAB|ENTER|ESCAPE|SPACE|BACKSPACE|UPARROW|LEFTARROW|RIGHTARROW|DOWNARROW|LALT|RALT|LCTRL|RCTRL|LSHIFT|RSHIFT|F1|F2|F3|F4|F5|F6|F7|F8|F9|F10|F11|F12|INS|DEL|PGDN|PGUP|HOME|END|MOUSE1|MOUSE2|MOUSE3|MOUSE4|MOUSE5|MOUSE1DBL|MOUSE2DBL|MOUSE3DBL|MOUSE4DBL|MOUSE5DBL|JOY1|JOY2|JOY3|JOY4|AUX1|AUX2|AUX3|AUX4|AUX5|AUX6|AUX7|AUX8|AUX9|AUX10|AUX11|AUX12|AUX13|AUX14|AUX15|AUX16|AUX17|AUX18|AUX19|AUX20|AUX21|AUX22|AUX23|AUX24|AUX25|AUX26|AUX27|AUX28|AUX29|AUX30|AUX31|AUX32|KP_HOME|KP_UPARROW|KP_PGUP|KP_LEFTARROW|KP_5|KP_RIGHTARROW|KP_END|KP_DOWNARROW|KP_PGDN|KP_ENTER|KP_INS|KP_DEL|KP_FSLASH|KP_STAR|KP_MINUS|KP_PLUS|MWHEELUP|MWHEELDOWN|PAUSE|SEMICOLON|CAPS|KP_SCROLL|KP_NUMLOCK|'|\\[|\\]|\\\\|\\/|\\.|\\-|\\=)\\b"
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "keyword.punctuation.definition.keyword.rmf",
+          "match": "(\\s\\-)|(\\s\\+)|(\\s\\!)"
+        },
+        {
+          "name": "constant.numeric.rmf",
+          "match": "(?x)(?:(?:\\b\\d(?:[\\d']*\\d)?\\.\\d(?:[\\d']*\\d)?|\\B\\.\\d(?:[\\d']*\\d)?)(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)?(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b|(?:\\b\\d(?:[\\d']*\\d)?\\.)(?:\\B|(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))\\b|(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b\\d(?:[\\d']*\\d)?(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b(?:(?:[1-9](?:[\\d']*\\d)?|0(?:[0-7']*[0-7])?|0[Xx][\\da-fA-F](?:[\\da-fA-F']*[\\da-fA-F])?|0[Bb][01](?:[01']*[01])?)(?:(?:l{1,2}|L{1,2})[uU]?|[uU](?:l{0,2}|L{0,2})|(?:i[fl]?|h|min|[mun]?s))?)\\b)"
+        }
+      ]
+    },
+    "macroexpand": {
+      "patterns": [
+        {
+          "name": "constant.character.escape.rmf",
+          "match": "(\\$)|(\\#)"
+        }
+      ]
+    },
+    "always": {
+      "patterns": [
+        {
+          "name": "variable.function.rmf",
+          "match": "\\b(vbargray|normaltext|hilitetext|backtint|tipback|tip|icontint|iconhilite|hgreen|hblue|lblue|lred|clear|black|transblack|semiblack|smokey|transgray|darkgray|gray|white|orange|red|blue|green|purple|cyan|header|yellow)\\b"
+        },
+        {
+          "name": "storage.type.rmf",
+          "match": "(?x)\\b(b_menu|bg_clear|spm_tint_1|spm_tint_2|spm_tint_3|spm_tint_4|spm_tint_5|spm_tint_6|spm_tint_7|spm_tint_8|spm_tint_9|spm_tint_11|spm_tint_12|spm_tint_14|spm_tint_15|spm_tint_16|spm_tint_17|spm_tint_18|spm_tint_19|spm_tint_20|spm_tint_21|spm_tint_22|spm_tint_23|spm_tint_24|spm_tint_25|spm_tint_26|spm_tint_27|spm_tint_28|spm_tint_29|spm_tint_30|spm_tint_31|spm_tint_menu_background|spm_tint_menu_normaltext|spm_tint_menu_hilitetext|spm_tint_menu_border|spm_tint_menu_background_top|spm_tint_menu_normaltext_top|spm_tint_menu_hilitetext_top|spm_tint_menu_disabledtext_top|spm_tint_menu_background_top_left|spm_tint_menu_normaltext_top_left|spm_tint_menu_hilitetext_top_left|spm_tint_menu_statictext|spm_tint_menu_scroll|spm_tint_menu_statictext_top|spm_tint_menu_border_top)\\b"
+        }
+      ]
     }
   }
 }
-
-

--- a/sof-vscode-syntax/syntaxes/sp.tmLanguage.json
+++ b/sof-vscode-syntax/syntaxes/sp.tmLanguage.json
@@ -1,6 +1,7 @@
 {
   "scopeName": "source.sp",
   "name": "SoF - String Package",
+  "firstLineMatch": "^VERSION",
   "patterns": [
     { "include": "#comment" },
     { "include": "#numbers" },
@@ -8,14 +9,111 @@
     { "include": "#strings" }
   ],
   "repository": {
-    "comment": { "patterns": [ { "name": "comment.line.double-slash.sp", "match": "//.*$" } ] },
-    "numbers": { "patterns": [ { "name": "constant.numeric.sp", "match": "\\b\\d+\\b" } ] },
-    "sections": {
+    "comment": {
       "patterns": [
-        { "name": "keyword.control.sp", "match": "^(?:VERSION|ID|REFERENCE|DESCRIPTION|COUNT|INDEX|FLAGS|TEXT_ENGLISH|TEXT_FRENCH|TEXT_GERMAN|TEXT_BRITISH|NOTES)\\b" }
+        {
+          "name": "comment.line.double-slash.sp",
+          "begin": "//",
+          "end": "$",
+          "patterns": [
+            {
+              "name": "comment.sp",
+              "match": ".*"
+            }
+          ]
+        }
       ]
     },
-    "strings": { "patterns": [ { "name": "string.quoted.double.sp", "begin": "\"", "end": "\"" } ] }
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.sp",
+          "match": "(?x)(?:(?:\\b\\d(?:[\\d']*\\d)?\\.\\d(?:[\\d']*\\d)?|\\B\\.\\d(?:[\\d']*\\d)?)(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)?(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b|(?:\\b\\d(?:[\\d']*\\d)?\\.)(?:\\B|(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))\\b|(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b\\d(?:[\\d']*\\d)?(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b(?:(?:[1-9](?:[\\d']*\\d)?|0(?:[0-7']*[0-7])?|0[Xx][\\da-fA-F](?:[\\da-fA-F']*[\\da-fA-F])?|0[Bb][01](?:[01']*[01])?)(?:(?:l{1,2}|L{1,2})[uU]?|[uU](?:l{0,2}|L{0,2})|(?:i[fl]?|h|min|[mun]?s|_\\w*))?)\\b)"
+        }
+      ]
+    },
+    "sections": {
+      "patterns": [
+        {
+          "name": "keyword.control.sp",
+          "match": "^VERSION\\b",
+          "captures": {
+            "0": { "name": "keyword.sp" }
+          }
+        },
+        {
+          "name": "keyword.control.sp",
+          "match": "^ID\\b",
+          "captures": {
+            "0": { "name": "keyword.sp" }
+          }
+        },
+        {
+          "name": "keyword.control.sp",
+          "match": "^REFERENCE\\b",
+          "captures": {
+            "0": { "name": "keyword.sp" }
+          }
+        },
+        {
+          "name": "keyword.control.sp",
+          "match": "^DESCRIPTION\\b",
+          "captures": {
+            "0": { "name": "keyword.sp" }
+          }
+        },
+        {
+          "name": "keyword.control.sp",
+          "match": "^COUNT\\b",
+          "captures": {
+            "0": { "name": "keyword.sp" }
+          }
+        },
+        {
+          "name": "keyword.control.sp",
+          "match": "^INDEX\\b",
+          "captures": {
+            "0": { "name": "keyword.sp" }
+          }
+        },
+        {
+          "name": "keyword.control.sp",
+          "match": "^FLAGS\\b",
+          "captures": {
+            "0": { "name": "keyword.sp" }
+          }
+        },
+        {
+          "name": "keyword.control.sp",
+          "match": "\\b(TEXT_ENGLISH|TEXT_FRENCH|TEXT_GERMAN|TEXT_BRITISH)\\b",
+          "captures": {
+            "0": { "name": "keyword.sp" }
+          }
+        },
+        {
+          "name": "string.sp",
+          "match": "^NOTES\\b",
+          "captures": {
+            "0": { "name": "string.sp" }
+          }
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.sp",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.sp",
+              "match": "\"\""
+            }
+          ]
+        }
+      ]
+    }
   }
 }
 

--- a/sof-vscode-syntax/syntaxes/wrs.tmLanguage.json
+++ b/sof-vscode-syntax/syntaxes/wrs.tmLanguage.json
@@ -1,20 +1,71 @@
 {
   "scopeName": "source.wrs",
   "name": "SoF - Waypoint Routes",
+  "firstLineMatch": "\\b(^Version)\\b",
   "patterns": [
     { "include": "#comment" },
     { "include": "#numbers" },
-    { "name": "keyword.other.wrs", "match": "\\b(?:begin|end)\\b" },
-    { "name": "entity.name.function.wrs", "match": "\\b(?:dm|team1|team2)\\b" },
-    { "name": "variable.function.bold.wrs", "match": "c[0-9]+" },
-    { "name": "keyword.version.wrs", "match": "^Version" },
+    { "include": "#keywords" },
     { "include": "#strings" }
   ],
   "repository": {
-    "comment": { "patterns": [ { "name": "comment.line.double-slash.wrs", "match": "//.*$" } ] },
-    "numbers": { "patterns": [ { "name": "constant.numeric.wrs", "match": "\\b\\d+\\b" } ] },
-    "strings": { "patterns": [ { "name": "string.quoted.double.wrs", "begin": "\"", "end": "\"" } ] }
+    "comment": {
+      "patterns": [
+        {
+          "name": "comment.line.double-slash.wrs",
+          "begin": "//",
+          "end": "$",
+          "patterns": [
+            {
+              "name": "comment.wrs",
+              "match": ".*"
+            }
+          ]
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.wrs",
+          "match": "(?x)(?:(?:\\b\\d(?:[\\d']*\\d)?\\.\\d(?:[\\d']*\\d)?|\\B\\.\\d(?:[\\d']*\\d)?)(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)?(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b|(?:\\b\\d(?:[\\d']*\\d)?\\.)(?:\\B|(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))\\b|(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b\\d(?:[\\d']*\\d)?(?:[Ee][+-]?\\d(?:[\\d']*\\d)?)(?:[fFlL]|(?:i[fl]?|h|min|[mun]?s|_\\w*))?\\b)|\\b(?:(?:[1-9](?:[\\d']*\\d)?|0(?:[0-7']*[0-7])?|0[Xx][\\da-fA-F](?:[\\da-fA-F']*[\\da-fA-F])?|0[Bb][01](?:[01']*[01])?)(?:(?:l{1,2}|L{1,2})[uU]?|[uU](?:l{0,2}|L{0,2})|(?:i[fl]?|h|min|[mun]?s|_\\w*))?)\\b)"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.wrs",
+          "match": "\\b(^Version)\\b"
+        },
+        {
+          "name": "keyword.wrs",
+          "match": "\\b(begin|end)\\b"
+        },
+        {
+          "name": "entity.name.function.wrs",
+          "match": "\\b(dm|team1|team2)\\b"
+        },
+        {
+          "name": "variable.function.wrs",
+          "match": "c[0-9]+"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.wrs",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.wrs",
+              "match": "\"\""
+            }
+          ]
+        }
+      ]
+    }
   }
 }
-
-


### PR DESCRIPTION
Convert all 16 `sof-sublime-syntax` files to `sof-vscode-syntax` (`.tmLanguage.json`) to provide accurate syntax highlighting for Soldier of Fortune file formats in VS Code.

This conversion ensures that VS Code offers the same rich syntax highlighting experience as Sublime Text for various Soldier of Fortune game files. It involved translating YAML-based Sublime Text syntax definitions to JSON-based tmLanguage definitions, preserving patterns and scopes, adding `firstLineMatch` for better detection, and correcting a `scopeName` in `package.json`.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b7c11e4-0dc3-427f-abf1-a684ebfa4ff5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8b7c11e4-0dc3-427f-abf1-a684ebfa4ff5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands all SoF `.tmLanguage.json` grammars with richer patterns and firstLineMatch, and corrects the `qe4` scopeName mapping.
> 
> - **Extension manifest**:
>   - Fix `package.json` grammar mapping for `sof-qe4` from `scopeName: "source.wrs"` to `"source.qe4"`.
> - **Syntax grammars (.tmLanguage.json)**:
>   - Add `firstLineMatch` where applicable and standardize comment handling to `begin`/`end` blocks with escapes.
>   - Replace simple numeric/string matches with comprehensive number regexes and escaped-quote handling.
>   - Substantially expand keywords, entities, commands, and sections across formats (`cfg`, `func`, `ds`, `def`, `rmf`, `qdt`, `gin`, `gpm`, `gbm`, `gsq`, `ifl`, `lst`, `wrs`, `bpf`).
>   - `qe4`: change `scopeName` to `source.qe4` and broaden keywords/flags; `def`, `rmf`, `qdt`, `cfg`, `func`, `ds` gain more structured repositories and control/command scopes.
>   - General: introduce additional repositories (e.g., layout/area/control) and refine tokenization for better VS Code highlighting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69487a74b7902f3dc9893fbc8e3cda98fc56df8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->